### PR TITLE
possibility to turn OFF time - consuming energy calibration

### DIFF
--- a/configFile.txt
+++ b/configFile.txt
@@ -5,7 +5,7 @@
 # DEBUG plots
 'debug_mode'            : 0,
 
-'ev'                    : 0,
+'ev'                    : 11,
 'nclu'                  : -1,        # -1
 
 # Plots that will be made if debug_mode = 1
@@ -52,6 +52,9 @@
 'vector_min_samples'    : [1, 150, 25, 20], #[5, 100, 40, 50] , # [30,  1180,  360, 80],  # [30,  55,  28, 13],
 'cuts'                  : [500, 100],
 'saturation_corr'       : False,
+
+# Superclusters parameters are hardcoded
+'calibrate_clusters'    : False,
 
 ### PMT waveform reconstruction
 'pmt_mode'              : 0,

--- a/configFile.txt
+++ b/configFile.txt
@@ -42,7 +42,7 @@
 
 'excImages'             : [], #list(range(5))+[],             # To exlude some images of the analysis. Always exclude the first 5 which are messy
 'min_neighbors_average' : 3.5,                     # cut on the minimum average energy around a pixel (remove isolated macro-pixels)
-'donotremove'           : True,                    # Remove or not the file from the tmp folder
+'donotremove'           : False,                    # Remove or not the file from the tmp folder
 
 # Setting i2DBSCAN parameters
 


### PR DESCRIPTION
for the time being just turn-off the energy calibration to reconstruct fast the LIME data (profiling says that it takes ~50% of the time to make the skeleton, slices, etc).

DEFAULT in the config-file is calibration OFF