### PR TITLE
Tmp option at runtime to be used at LNGS

### DIFF
--- a/reconstruction.py
+++ b/reconstruction.py
@@ -289,6 +289,7 @@ if __name__ == '__main__':
     parser.add_option('-j', '--jobs', dest='jobs', default=1, type='int', help='Jobs to be run in parallel (-1 uses all the cores available)')
     parser.add_option(      '--max-entries', dest='maxEntries', default=-1, type='float', help='Process only the first n entries')
     parser.add_option(      '--pdir', dest='plotDir', default='./', type='string', help='Directory where to put the plots')
+    parser.add_option(      '--tmp',  dest='tmpdir', default=None, type='string', help='Directory where to put the input file. If none is given, /tmp/<user> is used')
     
     (options, args) = parser.parse_args()
     
@@ -324,12 +325,15 @@ if __name__ == '__main__':
 
     USER = os.environ['USER']
     tmpdir = '/mnt/ssdcache/' if os.path.exists('/mnt/ssdcache/') else '/tmp/'
+    # override the default, if given by option
+    if options.tmpdir:
+        tmpdir = options.tmpdir
     os.system('mkdir -p {tmpdir}/{user}'.format(tmpdir=tmpdir,user=USER))
-    if sw.checkfiletmp(int(options.run)):
+    if sw.checkfiletmp(int(options.run),tmpdir):
         options.tmpname = "%s/%s/histograms_Run%05d.root" % (tmpdir,USER,int(options.run))
     else:
         print ('Downloading file: ' + sw.swift_root_file(options.tag, int(options.run)))
-        options.tmpname = sw.swift_download_root_file(sw.swift_root_file(options.tag, int(options.run)),int(options.run))
+        options.tmpname = sw.swift_download_root_file(sw.swift_root_file(options.tag, int(options.run)),int(options.run),tmpdir)
     
     if options.justPedestal:
         ana = analysis(options)

--- a/scripts/submit_batch.py
+++ b/scripts/submit_batch.py
@@ -68,6 +68,9 @@ if __name__ == "__main__":
         nThreads = min(8,nThreads)
     RAM = nThreads*1000
     ssdcache_opt = 'nodes=1:disk10,' if options.queue=='cygno-custom' else ''
+    # cygno-custom mounts /mnt/ssdcache, not the other queues. It seems that sometimes testing its presence works, sometimes not,
+    # so when not in cygno-custom, force the usage to /tmp
+    tmpdir_opt = '' if  options.queue=='cygno-custom' else ' --tmp /tmp/'
     commands = []
     for run in runs:
         job_file_name = jobdir+'/job_run{r}.sh'.format(r=run)
@@ -75,7 +78,7 @@ if __name__ == "__main__":
         tmp_file = open(job_file_name, 'w')
 
         tmp_filecont = jobstring
-        cmd = 'python3.8 reconstruction.py configFile.txt -r {r} -j {nt} '.format(r=run,nt=nThreads)
+        cmd = 'python3.8 reconstruction.py configFile.txt -r {r} -j {nt} {tmpopt}'.format(r=run,nt=nThreads,tmpopt=tmpdir_opt)
         tmp_filecont = tmp_filecont.replace('RECOSTRING',cmd)
         tmp_filecont = tmp_filecont.replace('CYGNOBASE',abswpath+'/')
         tmp_file.write(tmp_filecont)

--- a/swiftlib.py
+++ b/swiftlib.py
@@ -20,12 +20,12 @@ def reporthook(blocknum, blocksize, totalsize):
     else: # total size is unknown
         sys.stderr.write("read %d\n" % (readsofar,))
 
-def swift_download_root_file(url,run):
+def swift_download_root_file(url,run,tmp=None):
     import ROOT
     import os
     from urllib.request import urlretrieve
     USER = os.environ['USER']
-    tmpdir = '/mnt/ssdcache/' if os.path.exists('/mnt/ssdcache/') else '/tmp/'
+    tmpdir = tmp if tmp else ('/mnt/ssdcache/' if os.path.exists('/mnt/ssdcache/') else '/tmp/')
     os.system('mkdir -p {tmpdir}/{user}'.format(tmpdir=tmpdir,user=USER))
     tmpname = ("%s/%s/histograms_Run%05d.root" % (tmpdir,USER,run))
     urlretrieve(url, tmpname, reporthook)
@@ -61,10 +61,10 @@ def swift_rm_root_file(tmpname):
     os.remove(tmpname)
     print("tmp file removed")
 
-def checkfiletmp(run):
+def checkfiletmp(run,tmp=None):
     import os.path
     USER = os.environ['USER']
-    tmpdir = '/mnt/ssdcache/' if os.path.exists('/mnt/ssdcache/') else '/tmp/'
+    tmpdir = tmp if tmp else ('/mnt/ssdcache/' if os.path.exists('/mnt/ssdcache/') else '/tmp/')
     os.system('mkdir -p {tmpdir}/{user}'.format(tmpdir=tmpdir,user=USER))
     return os.path.isfile("%s/%s/histograms_Run%05d.root" % (tmpdir,USER,run))
 


### PR DESCRIPTION
Even if /mnt/ssdcache isn't mounted onn cygno nodes (only on cygno-custom), the check of its existence sometimes gives True, but then the copy fails.

So:

force the usage of /tmp when submitting to "cygno" queue at LNGS (this requires --tmp option to be added to reconstruction.py)