### PR TITLE
Adding sample_weight feature to the dbscan and ddbscan

### DIFF
--- a/cluster/ddbscan_.py
+++ b/cluster/ddbscan_.py
@@ -189,7 +189,7 @@ def ddbscan(X, eps=0.5, min_samples=40, dir_radius=1, dir_min_accuracy=0.8, dir_
     # A list of all core samples found.
     core_samples = np.asarray(n_neighbors >= min_samples, dtype=np.uint8)
     start = time.time()
-    labels = ddbscaninner(X, core_samples, neighborhoods, neighborhoods2, labels, min_samples, dir_radius, dir_min_accuracy, dir_minsamples, dir_thickness, time_threshold, max_attempts, isolation_radius)
+    labels = ddbscaninner(X, core_samples, neighborhoods, neighborhoods2, labels, dir_radius, dir_min_accuracy, dir_minsamples, dir_thickness, time_threshold, max_attempts, isolation_radius)
     final = time.time()
     #print("The ddbscaninner needed %d seconds." %(final-start))
     return np.where(core_samples)[0], labels

--- a/cluster/ddbscan_.py
+++ b/cluster/ddbscan_.py
@@ -21,7 +21,7 @@ from sklearn.neighbors import NearestNeighbors
 from cluster.ddbscan_inner import ddbscaninner
 import time
 
-def ddbscan(X, eps=0.5, min_samples=40, dir_radius=1, dir_min_accuracy=0.8, dir_minsamples=20, isolation_radius=100, time_threshold=np.inf, max_attempts=np.inf, dir_thickness=4, metric='minkowski', metric_params=None,  algorithm='auto', leaf_size=30, p=2, sample_weight=None, n_jobs=None):
+def ddbscan(X, eps=0.5, min_samples=40, dir_radius=1, dir_min_accuracy=0.8, dir_minsamples=20, isolation_radius=100, time_threshold=np.inf, max_attempts=np.inf, dir_thickness=4, metric='minkowski', metric_params=None,  algorithm='auto', leaf_size=30, p=2, sample_weight=None, n_jobs=None, expand_noncore = False):
     """Perform DBSCAN clustering from vector array or distance matrix.
 
     Read more in the :ref:`User Guide <dbscan>`.
@@ -189,7 +189,7 @@ def ddbscan(X, eps=0.5, min_samples=40, dir_radius=1, dir_min_accuracy=0.8, dir_
     # A list of all core samples found.
     core_samples = np.asarray(n_neighbors >= min_samples, dtype=np.uint8)
     start = time.time()
-    labels = ddbscaninner(X, core_samples, neighborhoods, neighborhoods2, labels, dir_radius, dir_min_accuracy, dir_minsamples, dir_thickness, time_threshold, max_attempts, isolation_radius)
+    labels = ddbscaninner(X, core_samples, neighborhoods, neighborhoods2, labels, dir_radius, dir_min_accuracy, dir_minsamples, dir_thickness, time_threshold, max_attempts, isolation_radius, expand_noncore)
     final = time.time()
     #print("The ddbscaninner needed %d seconds." %(final-start))
     return np.where(core_samples)[0], labels
@@ -322,6 +322,7 @@ class DDBSCAN(BaseEstimator, ClusterMixin):
         self.leaf_size     = params['leaf_size']
         self.p             = params['p']
         self.n_jobs        = params['n_jobs']
+        self.expand_noncore = params['expand_noncore']
 
     def fit(self, X, y=None, sample_weight=None):
         """Perform DBSCAN clustering from features or distance matrix.
@@ -345,7 +346,7 @@ class DDBSCAN(BaseEstimator, ClusterMixin):
         clust = ddbscan(X, eps=self.eps, min_samples=self.min_samples, dir_radius=self.dir_radius, dir_min_accuracy=self.dir_min_accuracy,
                         dir_minsamples=self.dir_minsamples, isolation_radius=self.isolation_radius, time_threshold=self.time_threshold, max_attempts=self.max_attempts,
                         dir_thickness=self.dir_thickness, metric=self.metric, metric_params=self.metric_params,
-                        algorithm=self.algorithm, leaf_size=self.leaf_size, p=self.p, sample_weight=sample_weight, n_jobs=self.n_jobs)
+                        algorithm=self.algorithm, leaf_size=self.leaf_size, p=self.p, sample_weight=sample_weight, n_jobs=self.n_jobs, expand_noncore = self.expand_noncore)
         self.core_sample_indices_, self.labels_ = clust
         if len(self.core_sample_indices_):
             # fix for scipy sparse indexing issue

--- a/cluster/ddbscan_inner.py
+++ b/cluster/ddbscan_inner.py
@@ -212,12 +212,18 @@ def ddbscaninner(data, is_core, neighborhoods, neighborhoods2, labels, dir_radiu
                         pts0 = pts1
                         moment_lab = np.where(labels==label_num)[0]
                         stack = []
+                        #If expand_noncore is not available, then only core_points will have its neighborhoods expanded
                         for j in moment_lab:
-                            neig2 = neighborhoods2[j]
-                            for k in neig2:
-                                #if labels[k] != label_num and labels[k]!=-1:
-                                if labels[k] != label_num:
-                                    stack.append(k)
+                            if expand_noncore:
+                                core_flag = 1
+                            else:
+                                core_flag = is_core[j]
+                            if core_flag:
+                                neig2 = neighborhoods2[j]
+                                for j in range(neig2.shape[0]):
+                                    v = neig2[j]
+                                    if labels[v] != label_num:
+                                        stack.append(v)
                         stack = np.unique(stack).tolist()
                         if len(stack) == 0:
                             break

--- a/cluster/ddbscan_inner.py
+++ b/cluster/ddbscan_inner.py
@@ -341,7 +341,7 @@ def ddbscaninner(data, is_core, neighborhoods, neighborhoods2, labels, dir_radiu
                 i = stack[len(stack)-1]
                 del(stack[len(stack)-1])
 
-            if sum(labels==label_num) > min_samples:
+            if sum(labels==label_num) >= min_samples:
                 label_num += 1
             else:
                 labels[labels==label_num] = len(data)

--- a/cluster/ddbscan_inner.py
+++ b/cluster/ddbscan_inner.py
@@ -296,10 +296,11 @@ def ddbscaninner(data, is_core, neighborhoods, neighborhoods2, labels, dir_radiu
                                     break
                 
 
-            if sum(labels==label_num) > min_samples:
-                label_num += 1
-            else:
-                labels[labels==label_num] = len(data)
+            label_num += 1
+
+        for i in range(label_num):
+            if sum(labels==i) < min_samples:
+                labels[labels==i] = len(data)
 
         ddbsc_t2=time.time()
         if debug:
@@ -368,7 +369,6 @@ def ddbscaninner(data, is_core, neighborhoods, neighborhoods2, labels, dir_radiu
         
             
             
-        
         
         
         

--- a/configFile.txt
+++ b/configFile.txt
@@ -1,20 +1,20 @@
 {
 # DETECTOR
-'geometry'  : 'lime',
+'geometry'  : 'lemon',
 
 # DEBUG plots
-'debug_mode'            : 0,
+'debug_mode'            : 1,
 
-'ev'                    : 40,
+'ev'                    : 12,
 'nclu'                  : -1,        # -1
 
 # Plots that will be made if debug_mode = 1
 
-'flag_full_image'       : 1,
-'flag_rebin_image'      : 1,
-'flag_edges_image'      : 1,
+'flag_full_image'       : 0,
+'flag_rebin_image'      : 0,
+'flag_edges_image'      : 0,
 'flag_polycluster'      : 1,
-'flag_dbscan_seeds'     : 0,
+'flag_dbscan_seeds'     : 1,
 'flag_stats'            : 1,
 
 'camera_mode'            : 1,
@@ -29,20 +29,20 @@
 'numPedEvents'          : -1,
 'pedExclRegion'         : None,
 'rebin'                 : 4,
-'nsigma'                : 1.5,
-'cimax'                 : 5000,                    # Upper threshold (keep very high not to kill large signals)
+'nsigma'                : 1.3,
+'cimax'                 : 200,                    # Upper threshold (keep very high not to kill large signals)
 'justPedestal'          : False,
 'daq'                   : 'midas',                 # DAQ type (btf/h5/midas)
 'type'                  : 'neutrons',              # events type (beam/cosmics/neutrons)
 'tag'                   : 'Data',                  # 'Data' for experimental data or 'MC' for Simulated data, DataMango for MANGO data at LNGS
-'vignetteCorr'          : True,                    # apply vignetting correction (correction maps in data/ according to the geometry)
+'vignetteCorr'          : False,                    # apply vignetting correction (correction maps in data/ according to the geometry)
 
-'excImages'             : [], #list(range(5))+[],             # To exlude some images of the analysis. Always exclude the first 5 which are messy
+'excImages'             : [0,1,2,3,4], #list(range(5))+[],             # To exlude some images of the analysis. Always exclude the first 5 which are messy
 'min_neighbors_average' : 3.5,                     # cut on the minimum average energy around a pixel (remove isolated macro-pixels)
 'donotremove'           : True,                    # Remove or not the file from the tmp folder
 
 
-'tip'                   : '2D',
+'tip'                   : '3D',
 'saturation_corr'       : False,
 
 # Superclusters parameters are hardcoded

--- a/configFile.txt
+++ b/configFile.txt
@@ -3,9 +3,9 @@
 'geometry'  : 'lemon',
 
 # DEBUG plots
-'debug_mode'            : 1,
+'debug_mode'            : 0,
 
-'ev'                    : 12,
+'ev'                    : 106,
 'nclu'                  : -1,        # -1
 
 # Plots that will be made if debug_mode = 1

--- a/modules_config/clustering.txt
+++ b/modules_config/clustering.txt
@@ -2,18 +2,18 @@
 
 ## DBSCAN seeding
 'dim'                : '3D',
-'dbscan_eps'         : 5.5,
-'dbscan_minsamples'  : 17, # this is for 2D
+'dbscan_eps'         : 5.8,
+'dbscan_minsamples'  : 30, # this is for 2D
 
 ## directional clustering
-'dir_radius'         : 30,
+'dir_radius'         : 15.5,
 'dir_min_accuracy'   : 0.8, # minimum accuracy of the RANSAC to save one point of the cluster for the directional search
-'dir_minsamples'     : 50, ## N.B. this is always 2D, and it may differ from dbscan_minsamples (that can be Npix * intensity for 3D)
+'dir_minsamples'     : 40, ## N.B. this is always 2D, and it may differ from dbscan_minsamples (that can be Npix * intensity for 3D)
 'dir_thickness'      : 5.5,
 'time_threshold'     : 300, # seconds
-'max_attempts'       : 5,
+'max_attempts'       : 8,
 'isolation_radius'   : 50,
-'metric'             : 'cityblock',
+'metric'             : 'euclidean',
 'metric_params'      : None,
 'algorithm'          : 'auto',
 'leaf_size'          : 30,

--- a/modules_config/clustering.txt
+++ b/modules_config/clustering.txt
@@ -8,7 +8,7 @@
 ## directional clustering
 'dir_radius'         : 15.5,
 'dir_min_accuracy'   : 0.8, # minimum accuracy of the RANSAC to save one point of the cluster for the directional search
-'dir_minsamples'     : 40, ## N.B. this is always 2D, and it may differ from dbscan_minsamples (that can be Npix * intensity for 3D)
+'dir_minsamples'     : 50, ## N.B. this is always 2D, and it may differ from dbscan_minsamples (that can be Npix * intensity for 3D)
 'dir_thickness'      : 5.5,
 'time_threshold'     : 300, # seconds
 'max_attempts'       : 8,
@@ -18,5 +18,6 @@
 'algorithm'          : 'auto',
 'leaf_size'          : 30,
 'p'                  : None,
-'n_jobs'             : None
+'n_jobs'             : None,
+'expand_noncore'     : True,
 }

--- a/modules_config/clustering.txt
+++ b/modules_config/clustering.txt
@@ -11,8 +11,8 @@
 'dir_minsamples'     : 50, ## N.B. this is always 2D, and it may differ from dbscan_minsamples (that can be Npix * intensity for 3D)
 'dir_thickness'      : 5.5,
 'time_threshold'     : 300, # seconds
-'max_attempts'       : 8,
-'isolation_radius'   : 50,
+'max_attempts'       : 13,
+'isolation_radius'   : 5,
 'metric'             : 'euclidean',
 'metric_params'      : None,
 'algorithm'          : 'auto',

--- a/pedestals/pedruns.txt
+++ b/pedestals/pedruns.txt
@@ -9,4 +9,5 @@
 (3933,3938) :   3938, # ORCA flash pedestals 
 (3939,3944) :   3944, # ORCA fusion pedestals 
 (3930,3932) :   2311, # white pictures for vignetting (old camera)
+(2316,2321) :   2316
 }

--- a/pedestals/pedruns.txt
+++ b/pedestals/pedruns.txt
@@ -9,5 +9,8 @@
 (3933,3938) :   3938, # ORCA flash pedestals 
 (3939,3944) :   3944, # ORCA fusion pedestals 
 (3930,3932) :   2311, # white pictures for vignetting (old camera)
-(2316,2321) :   2316
+(2316,2321) :   2316,
+(2096,2099) :	2170,
+(2155,2164) :   2155,
+(2053,2055) :	2155
 }

--- a/reconstruction.py
+++ b/reconstruction.py
@@ -322,7 +322,7 @@ if __name__ == '__main__':
     
     if options.debug_mode == 1:
         setattr(options,'outFile','reco_run%d_%s_debug.root' % (run, options.tip))
-        if options.ev: options.maxEntries = options.ev + 1
+        #if options.ev: options.maxEntries = options.ev + 1
         #if options.daq == 'midas': options.ev +=0.5 
     else:
         setattr(options,'outFile','reco_run%05d_%s.root' % (run, options.tip))
@@ -347,9 +347,11 @@ if __name__ == '__main__':
     # override the default, if given by option
     if options.tmpdir:
         tmpdir = options.tmpdir
-    os.system('mkdir -p {tmpdir}/{user}'.format(tmpdir=tmpdir,user=USER))
+
+    #os.system('mkdir -p {tmpdir}/{user}'.format(tmpdir=tmpdir,user=USER))
     if sw.checkfiletmp(int(options.run),tmpdir):
-        options.tmpname = "%s/%s/histograms_Run%05d.root" % (tmpdir,USER,int(options.run))
+        options.tmpname = "%s/histograms_Run%05d.root" % (tmpdir,int(options.run))
+        print(options.tmpname)
     else:
         print ('Downloading file: ' + sw.swift_root_file(options.tag, int(options.run)))
         options.tmpname = sw.swift_download_root_file(sw.swift_root_file(options.tag, int(options.run)),int(options.run),tmpdir)

--- a/snakes.py
+++ b/snakes.py
@@ -76,12 +76,13 @@ class SnakesFactory:
         ## apply vignetting (if not applied, vignette map is all ones)
         ## this is done only for energy calculation, not for clustering (would make it crazy)
         image_fr_vignetted = self.ct.vignette_corr(self.image_fr,self.vignette)
-        image_fr_zs_vignetted = self.ct.vignette_corr(self.image_fr_zs,self.vignette)
-                
+        image_fr_zs_vignetted = self.ct.vignette_corr(self.image_fr_zs,self.vignette)    
         if tip=='3D':
             sample_weight = np.take(self.image, self.image.shape[0]*points[:,0]+points[:,1]).astype(int)
             sample_weight[sample_weight==0] = 1
             X = points.copy()
+            np.save('data24', X)
+            np.save('sample24', sample_weight)
             
         else:
             X = points.copy()
@@ -123,13 +124,12 @@ class SnakesFactory:
         if self.options.debug_mode: print(f"basic clustering in {t1 - t0:0.4f} seconds")
         t2 = time.perf_counter()
         if self.options.debug_mode: print(f"ddbscan clustering in {t2 - t1:0.4f} seconds")
-        
         # Black removed and is used for noise instead.
         unique_labels = set(ddb.labels_[:,0])
 
         # Number of polynomial clusters in labels, ignoring noise if present.
         n_superclusters = len(unique_labels) - (1 if -1 in ddb.labels_[:,0] else 0)
-
+        
         for k in unique_labels:
             if k == -1:
                 break # noise: the unclustered
@@ -189,12 +189,13 @@ class SnakesFactory:
             if self.options.flag_stats == 1:
                 print('[Statistics]')
                 print("Polynomial clusters found: %d" % n_superclusters)
+                
 
 
             if self.options.flag_polycluster == 1:
                 print('[Plotting 0th iteration]')
                 u,indices = np.unique(ddb.labels_,return_index = True)
-                clu = [X[ddb.labels_[:,0] == i] for i in range(len(set(ddb.labels_[:,0])) - (1 if -1 in ddb.labels_[:,0] else 0))]
+                clu = [X[ddb.labels_[:,0] == i] for i in np.unique(ddb.labels_[:,0]) if i != -1]
                 fig = plt.figure(figsize=(self.options.figsizeX, self.options.figsizeY))
                 plt.imshow(self.image,cmap=self.options.cmapcolor,vmin=vmin, vmax=vmax,origin='lower' )
                 plt.title("Polynomial clusters found in iteration 0")

--- a/snakes.py
+++ b/snakes.py
@@ -145,8 +145,8 @@ class SnakesFactory:
 
         # - - - - - - - - - - - - - -
         t1 = time.perf_counter()
-        #ddb = DDBSCAN('modules_config/clustering.txt').fit(X, sample_weight = sample_weight)
-        ddb = DBSCAN(eps=5.8,min_samples=30).fit(X, sample_weight = sample_weight)
+        ddb = DDBSCAN('modules_config/clustering.txt').fit(X, sample_weight = sample_weight)
+        #ddb = DBSCAN(eps=5.8,min_samples=30).fit(X, sample_weight = sample_weight)
         t2 = time.perf_counter()
         if self.options.debug_mode: print(f"pre-processing + dbscan in {t1 - t0:0.4f} seconds")
         if self.options.debug_mode: print(f"dbscan in {time1 - time0:0.4f} seconds")

--- a/snakes.py
+++ b/snakes.py
@@ -81,8 +81,7 @@ class SnakesFactory:
             sample_weight = np.take(self.image, self.image.shape[0]*points[:,0]+points[:,1]).astype(int)
             sample_weight[sample_weight==0] = 1
             X = points.copy()
-            np.save('data24', X)
-            np.save('sample24', sample_weight)
+
             
         else:
             X = points.copy()

--- a/snakes.py
+++ b/snakes.py
@@ -79,9 +79,10 @@ class SnakesFactory:
         image_fr_zs_vignetted = self.ct.vignette_corr(self.image_fr_zs,self.vignette)
                 
         if tip=='3D':
-            sample_weight = np.array([round(edges[ix,iy]) for ix,iy in points],dtype=np.int)
+            sample_weight = np.take(self.image, self.image.shape[0]*points[:,0]+points[:,1]).astype(int)
             sample_weight[sample_weight==0] = 1
             X = points.copy()
+            
         else:
             X = points.copy()
             sample_weight = np.full(X.shape[0], 1, dtype=np.int)
@@ -114,6 +115,7 @@ class SnakesFactory:
      
                 for ext in ['png','pdf']:
                     plt.savefig('{pdir}/{name}_{esp}_{tip}.{ext}'.format(pdir=outname, name=self.name, esp='1st', ext=ext, tip=self.options.tip), bbox_inches='tight', pad_inches=0)
+                    
 
         # - - - - - - - - - - - - - -
         t1 = time.perf_counter()
@@ -152,8 +154,8 @@ class SnakesFactory:
             print('[DEBUG-MODE ON]')
             print('[%s Method]' % (self.options.tip))
 
-            if self.options.flag_full_image or self.options.flag_rebin_image or self.options.flag_edges_image or self.options.flag_first_it or self.options.flag_second_it or self.options.flag_third_it or self.options.flag_all_it or self.options.flag_supercluster :
-                import matplotlib.pyplot as plt
+            #if self.options.flag_full_image or self.options.flag_rebin_image or self.options.flag_edges_image or self.options.flag_first_it or self.options.flag_second_it or self.options.flag_third_it or self.options.flag_all_it or self.options.flag_supercluster :
+            import matplotlib.pyplot as plt
 
             if self.options.flag_full_image == 1:
                 fig = plt.figure(figsize=(self.options.figsizeX, self.options.figsizeY))


### PR DESCRIPTION
The sample_weight is a parameter of the method fit( ) of the DBSCAN. It allows to use the benefits of the 3D without having to use the replicated points, so the speed of the algorithms is similar to the speed by using 2D. The DBSCAN didn't need modifications in order the use this new parameter, but the DDBSCAN needed.
General modifications:
I had to remove the "false cluster remotion" done by the min_samples. It is done by the length of the smallest cluster found in the DBSCAN part instead of using the min_samples now.
The parts that eliminate replicated points to send to the RANSAC or to compare to the dir_minsamples are not necessary anymore.
Specific modifications for the 2320 and 2317 runs:
I had to change the metric using by the DBSCAN to "Euclidian"
I had to enable the directional search through non-core points to find faint tracks.
