### PR TITLE
new paths on the cloud for cygno

### DIFF
--- a/swiftlib.py
+++ b/swiftlib.py
@@ -3,7 +3,13 @@
 def swift_root_file(tag, run):
     sel = rootlocation(tag,run)    
     
-    BASE_URL  = "https://swift.cloud.infn.it:8080/v1/AUTH_1e60fe39fba04701aa5ffc0b97871ed8/Cygnus/"
+    BASE_URL = "https://s3.cloud.infn.it/v1/AUTH_2ebf769785574195bde2ff418deac08a/"
+    if 'MC' in tag:
+        bucket = 'cygnus' if tag=='MC-old' else 'cygno-sim'
+    else:
+        bucket = 'cygnus' if run<4470 else 'cygno-data'
+    BASE_URL = BASE_URL + bucket + '/'
+
     file_root = (sel+'/histograms_Run%05d.root' % run)
     return BASE_URL+file_root
 
@@ -36,10 +42,12 @@ def rootlocation(tag,run):
     if tag == 'Data':
         if (run>=936) and (run<=1601):
             sel = 'Data/LTD/Data_Camera/ROOT'
-        elif (run>=1632) and (run<=4000):
+        elif (run>=1632) and (run<4470):
             sel = 'Data/LAB'
+        elif (run>=4469) and (run<10000):
+            sel = 'LAB'
         elif tag == 'DataMango':
-            sel= 'Data/MAN'
+            sel= 'Data/MAN' if run<10000 else 'MAN' ### exact run number switch to new bucket for MANGO to be implemented
         else:
             print("WARNING: Data taken with another DAQ or not yet uploaded to the cloud")
             exit()
@@ -48,7 +56,7 @@ def rootlocation(tag,run):
         sel = 'Simulation'
         print("WARNING: automatic download for Simulated data not implemented yet")
         exit()
- 
+        
     return sel
 
 def swift_read_root_file(tmpname):


### PR DESCRIPTION
Following message by @gmazzitelli (reported here):

----- 
WARNING!
We are reviewing the CYGNO storage space and policy in order to provide different access to people involved simulation and analysis 

cygno-data (15TB) only DAQ machine (and admin) can write, everybody can read also via HTTP (see below)
cygno-analysis (5TB) cygno user can read/write 
cygno-sim (10TB) cygno user can read/write 
old cygnus bucket (5TB) contain file up to 4469 (https://s3.cloud.infn.it/v1/AUTH_2ebf769785574195bde2ff418deac08a/cygnus/Data/LAB/histograms_Run0XXXX.root)

Than means  that since data file 04470 http address to data change to:
https://s3.cloud.infn.it/v1/AUTH_2ebf769785574195bde2ff418deac08a/cygno-data/LAB/histograms_Run0XXXX.root
(New bucket cygno-data instead of cygnus and  the subpath “Data" removed )
Es
https://s3.cloud.infn.it/v1/AUTH_2ebf769785574195bde2ff418deac08a/cygno-data/LAB/histograms_Run04557.root

All data stored are also accessible via https://minio.cloud.infn.it/ for cloud users.

This are initial assignment that will be increase if needed

WARNING (Giorgio!) for LNGS MANGO DAQ: please change the bucket from cygnus to cygno-data and remove Data in the script if you want to use new repo. There is stil space on the old repo so if you want you can still use the old one.

Let me know any issue, Giovanni