### PR TITLE
Little tuning for 2021 LIME data

### DIFF
--- a/configFile.txt
+++ b/configFile.txt
@@ -27,7 +27,7 @@
 
 'numPedEvents'          : -1,
 'pedExclRegion'         : None,
-'rebin'                 : 6,
+'rebin'                 : 4,
 'nsigma'                : 1.3,
 'cimax'                 : 5000,                    # Upper threshold (keep very high not to kill large signals)
 'justPedestal'          : False,
@@ -38,7 +38,7 @@
 
 'excImages'             : list(range(5))+[],       # To exlude some images of the analysis. Always exclude the first 5 which are messy
 'min_neighbors_average' : 0.55,                    # cut on the minimum average energy around a pixel (remove isolated macro-pixels)
-'donotremove'           : False,                   # Remove or not the file from the tmp folder
+'donotremove'           : True,                   # Remove or not the file from the tmp folder
 
 
 'tip'                   : '3D',

--- a/modules_config/clustering.txt
+++ b/modules_config/clustering.txt
@@ -2,7 +2,7 @@
 
 ## DBSCAN seeding
 'dim'                : '3D',
-'dbscan_eps'         : 1.3,
+'dbscan_eps'         : 1.1,
 'dbscan_minsamples'  : 5, # this is for 2D #
 
 ## directional clustering


### PR DESCRIPTION
For this data one can reduce the DBSCan radius and make the rebin smaller.
The main reason is that the aperture is 10 ms vs 50ms of August2021 data and cosmics background is much smaller