### PR TITLE
add the possibility to submit a custom run range with a text file

### DIFF
--- a/datasets/lime_April2021.txt
+++ b/datasets/lime_April2021.txt
@@ -1,0 +1,8 @@
+runs = list(range(4120,4190))
+pedestals = list(range(4119,4191,8))
+for p in pedestals:
+    if p in runs:
+       runs.remove(p)
+
+
+

--- a/pedestals/pedruns.txt
+++ b/pedestals/pedruns.txt
@@ -16,6 +16,7 @@
 (4374,4383) :   4374, # X rays variable energy (200 ms)
 (4384,4391) :   4384, # X rays variable energy (50 ms)
 (4117,4118) :   4418, # 13/04 Lime RING FC test
+(4119,4190) :   4119, # 13/04 Lime Z-scan
 (4432,4469) :   4432, # Fe Vg1, Z scans, 30/07/2021
 (4470,4504) :   4470, # variable X-rays source
 }


### PR DESCRIPTION
If one has a run range with holes, instead of giving "[minrun-maxrun]" as input of the script, give as input a text file:

* Example:
`python scripts/submit_batch.py $PWD datasets/lime_April2021.txt --outdir test_batch --dry-run --mh 8 --nev 200 10`

The input file is executed in python, so it can be python code returning "runs" as a python list. See the example in the example file