### PR TITLE
Remove debug printouts in ddbscan_inner and reduce the rebin + loosen the noise threshold

### DIFF
--- a/cluster/ddbscan_inner.py
+++ b/cluster/ddbscan_inner.py
@@ -69,7 +69,7 @@ def ransac_polyfit(x,y,order,t,n=0.7,k=100,f=0.8):
 # k - Number of tries 
 # f - Accuracy of the RANSAC to consider the fit a good one
 
-def ddbscaninner(data, is_core, neighborhoods, neighborhoods2, labels, dir_radius, dir_min_accuracy, dir_minsamples, dir_thickness, time_threshold, max_attempts, isolation_radius, expand_noncore, debug=True):
+def ddbscaninner(data, is_core, neighborhoods, neighborhoods2, labels, dir_radius, dir_min_accuracy, dir_minsamples, dir_thickness, time_threshold, max_attempts, isolation_radius, expand_noncore, debug=False):
     #Definitions
     #Beginning of the algorithm - DBSCAN check part
     label_num = 0

--- a/cluster/ddbscan_inner.py
+++ b/cluster/ddbscan_inner.py
@@ -118,10 +118,6 @@ def ddbscaninner(data, is_core, neighborhoods, neighborhoods2, labels, dir_radiu
                 print("==> cluster ",i," has ",sum(labels==label_num)," samples")
             x = data[labels==label_num][:,0]
             y = data[labels==label_num][:,1]
-            #ransac = RANSACRegressor(PolynomialRegression(degree=3),
-            #                         residual_threshold=3 * np.std(y),
-            #                         random_state=0,)
-            #ransac.fit(np.expand_dims(x, axis=1), y)
             if (np.median(np.abs(y - np.median(y))) == 0):
                 ransac = RANSACRegressor(min_samples=0.8, residual_threshold = 0.3)
                 ransac.fit(np.expand_dims(x, axis=1), y)

--- a/cluster/ddbscan_inner.py
+++ b/cluster/ddbscan_inner.py
@@ -120,7 +120,7 @@ def ddbscaninner(data, is_core, neighborhoods, neighborhoods2, labels, dir_radiu
             y = data[labels==label_num][:,1]
             ransac = RANSACRegressor(PolynomialRegression(degree=3),
                                      residual_threshold=3 * np.std(y),
-                                     random_state=0)
+                                     random_state=0,min_samples=min_samples)
             ransac.fit(np.expand_dims(x, axis=1), y)
             #if (np.median(np.abs(y - np.median(y))) == 0):
             #    ransac = RANSACRegressor(min_samples=0.8, residual_threshold = 0.1)

--- a/configFile.txt
+++ b/configFile.txt
@@ -28,7 +28,7 @@
 'numPedEvents'          : -1,
 'pedExclRegion'         : None,
 'rebin'                 : 4,
-'nsigma'                : 1.3,
+'nsigma'                : 1.2,
 'cimax'                 : 5000,                    # Upper threshold (keep very high not to kill large signals)
 'justPedestal'          : False,
 'daq'                   : 'midas',                 # DAQ type (btf/h5/midas)
@@ -36,8 +36,8 @@
 'tag'                   : 'Data',                  # 'Data' for experimental data or 'MC' for Simulated data, DataMango for MANGO data at LNGS
 'vignetteCorr'          : True,                    # apply vignetting correction (correction maps in data/ according to the geometry)
 
-'excImages'             : list(range(5))+[],       # To exlude some images of the analysis. Always exclude the first 5 which are messy
-'min_neighbors_average' : 0.55,                    # cut on the minimum average energy around a pixel (remove isolated macro-pixels)
+'excImages'             : list(range(5))+[],      # To exlude some images of the analysis. Always exclude the first 5 which are messy
+'min_neighbors_average' : 0.75,                   # cut on the minimum average energy around a pixel (remove isolated macro-pixels)
 'donotremove'           : True,                   # Remove or not the file from the tmp folder
 
 

--- a/pedestals/pedruns.txt
+++ b/pedestals/pedruns.txt
@@ -1,5 +1,6 @@
 {
 # format: (first_run, last_run), ped_run,
+(1000,1003) :   1000, # runs taken manually 3/11/2021 (Ti source - run numbers are fictive)
 (2316,2321) :   2316,
 (2096,2099) :	2170,
 (2155,2164) :   2155,
@@ -14,6 +15,7 @@
 (3930,3932) :   2311, # white pictures for vignetting (old camera)
 (4374,4383) :   4374, # X rays variable energy (200 ms)
 (4384,4391) :   4384, # X rays variable energy (50 ms)
+(4396,4415) :   4396, # high statistics variable X-rays source (50 ms)
 (4117,4118) :   4418, # 13/04 Lime RING FC test
 (4119,4190) :   4119, # 13/04 Lime Z-scan
 (4432,4469) :   4432, # Fe Vg1, Z scans, 30/07/2021


### PR DESCRIPTION
* rebin: moved back to 4. This is more convenient for data taken **overground** and with hokawo, **small exposure time**. For the standard DAQ this should be 6, to survive
* noise: loosened the threshold from 1.3xsigma => 1.2xsigma. Simultaneously, needed to tighten a bit the noise salt&pepper filter