### PR TITLE
Skip folders with event info if tag=MC

### DIFF
--- a/reconstruction.py
+++ b/reconstruction.py
@@ -227,7 +227,13 @@ class analysis:
 
             name=key.GetName()
             obj=key.ReadObj()
-
+            
+            if self.options.tag=="MC":
+                if name=="event_info":
+                    continue
+                if name=="param_dir":
+                    continue
+            
             if 'pic' in name:
                 patt = re.compile('\S+run(\d+)_ev(\d+)')
                 m = patt.match(name)


### PR DESCRIPTION
When you try to run on MC data, you get this error message:

```
UnboundLocalError: local variable 'event' referenced before assignment
```
In fact, the MC root file has two folders (`event_info` and `param_dir`), so the `event` variable can't be defined for those.

To prevent that, you have to skip those two folders in the for loop that reads the images.

@igorabritta suggested this change. 

I think @gdimperi can benefit from this as well. 