### PR TITLE
Fix the multithreading with new version of python3 libraries

### DIFF
--- a/reconstruction.py
+++ b/reconstruction.py
@@ -520,6 +520,7 @@ if __name__ == '__main__':
             executor.map(ana,chunks)
             py_version = sys.version_info
             if ( py_version.major == 3 ) and ( py_version.minor < 9 ):
+                import queue
                 executor.shutdown( wait = True )
                 while True:
                     # cancel all waiting tasks


### PR DESCRIPTION
**Needed to make a drastic change from multiprocessing to concurrent.futures.ThreadPoolExecutor** to run again with multithread at LNGS. The update of the libraries was needed due to the change in the raw data format (midas, cygno lib, and all of that...)

Did a bit of cleanup of the code. Now practically the code is running as before, but with a worrisome feature to remind for future investiations:

- the analysis object passed to the ThreadPoolExecutor is duplicated, but the ROOT directory and also other members are overwritten depending from the different threads.
- the net effect is that the output events are written randomly in the chunks (and some can be empty at the end), but after the final hadd everything seems in. 

Since this may have some strange and unexpected effect, keep monitoring after a large production (if all the events are written in the output).
