### PR TITLE
Move from multi-thread to multi-process for ROOT happiness

### DIFF
--- a/reconstruction.py
+++ b/reconstruction.py
@@ -66,7 +66,10 @@ class analysis:
         
     def beginJob(self,outfname):
         # prepare output file
+        ROOT.EnableThreadSafety()
         self.outputFile = ROOT.TFile.Open(outfname, "RECREATE")
+        print("Opening out file: ",outfname," self.outputFile = ",self.outputFile)
+        ROOT.gDirectory.cd()
         # prepare output tree
         self.outputTree = ROOT.TTree("Events","Tree containing reconstructed quantities")
         self.outTree = OutputTree(self.outputFile,self.outputTree)
@@ -103,9 +106,7 @@ class analysis:
 
     def endJob(self):
         self.outTree.write()
-        # ok this is a hack: for some reason when running in multicore the tree is written randomly in some of the open chunk files
-        # so leave it open, it doesn't harm the final hadd
-        # self.outputFile.Close()
+        self.outputFile.Close()
         
     def getNEvents(self,options):
         if options.rawdata_tier == 'root':
@@ -484,7 +485,6 @@ if __name__ == '__main__':
     # in case of MIDAS, download function checks the existence and in case it is absent, dowloads it. If present, opens it
     if options.rawdata_tier == 'midas':
         ## need to open it (and create the midas object) in the function, otherwise the async run when multithreaded will confuse events in the two threads
-        #options.tmpname = sw.swift_download_midas_file(int(options.run),tmpdir,options.tag)
         options.tmpname = [int(options.run),tmpdir,options.tag]
     print ("here file is: ",options.tmpname)
     if options.justPedestal:
@@ -516,22 +516,11 @@ if __name__ == '__main__':
         nj = int(nev/nThreads) if options.maxEntries==-1 else max(int((lastEvent-firstEvent)/nThreads),1)
         chunks = [(ichunk,i,min(i+nj-1,nev)) for ichunk,i in enumerate(range(firstEvent,lastEvent,nj))]
         print("Chunks = ",chunks)
-        with futures.ThreadPoolExecutor(nThreads) as executor:
-            executor.map(ana,chunks)
-            py_version = sys.version_info
-            if ( py_version.major == 3 ) and ( py_version.minor < 9 ):
-                import queue
-                executor.shutdown( wait = True )
-                while True:
-                    # cancel all waiting tasks
-                    try:
-                        work_item = executor._work_queue.get_nowait()
-                    except queue.Empty:
-                        break
-                    if work_item is not None:
-                        work_item.future.cancel()
-            else:
-                executor.shutdown(wait=True, cancel_futures=False)
+        with futures.ProcessPoolExecutor(nThreads) as executor:
+            futures_list = [executor.submit(ana,c) for c in chunks]
+            for future in futures.as_completed(futures_list):
+                # retrieve the result. This is crucial, because result() does not exit until the process is completed.
+                future.result()
         print("Now hadding the chunks...")
         base = options.outFile.split('.')[0]
         if flag_env == 0:
@@ -546,7 +535,7 @@ if __name__ == '__main__':
     print(f'Reconstruction Code Took: {t2 - t1} seconds')
 
     # now add the git commit hash to track the version in the ROOT file
-    tf = ROOT.TFile.Open(options.outFile,'update')
+    tf = ROOT.TFile.Open("{outdir}/{base}.root".format(base=base, outdir=options.outdir),'update')
     githash = ROOT.TNamed("gitHash",str(utilities.get_git_revision_hash()).replace('\n',''))
     githash.Write()
     tf.Close()


### PR DESCRIPTION
This seems something trivial, but the former shares the memory among the different threads, the second keeps the memory of each subprocess separate and this fixes completely the issue of the chunk TFiles being filled randomly (and provoking crash if one of the TFile is not opened when another asyncronous jobs want to write there).

So this is a crucial fix of PR #186 for running with python 3.8 with many many subprocesses at the LNGS queues. 

This of course crashes on my laptop (only in multithread mode) with python3.9, but this is something for another nightmares night.
