### PR TITLE
implement the Davide Marin cosmics veto, useful for LNF

### DIFF
--- a/plotter/functions.cc
+++ b/plotter/functions.cc
@@ -34,6 +34,30 @@ float R(float x, float y, float width=2304) {
   return hypot(x-halfwidth,y-halfwidth);
 }
 
+double marinDistance(double x_min, double x_max, double y_min, double y_max, double x_mean, double y_mean) {
+  double m = (y_min-y_max)/(1e-9+x_min-x_max);
+  double q = y_min - m*x_min;
+  return fabs(y_mean - m*x_mean)/sqrt(1+pow(m,2));
+}
+
+double marinTheta(double x_min, double x_max, double y_min, double y_max, double x_mean, double y_mean) {
+  return marinDistance(x_min, x_max, y_min, y_max, x_mean, y_mean) < marinDistance(x_max, x_min, y_min, y_max, x_mean, y_mean) ? fabs(std::atan((y_min-y_max)/(x_min-x_max+1e-10))) : fabs(std::atan((y_min-y_max)/(x_max-x_min+1e-10)));
+}
+
+double cosmics(double l,double c) {
+  // l must be in [mm]
+  return c<l ? 1.568 - 1.033 * asin(c/l) : -1;
+}
+
+int marinBand(double length, double x_min, double x_max, double y_min, double y_max, double x_mean, double y_mean) {
+  double cmin=90, cmax=100; // mm
+  double l = 0.152 * length; // mm
+  double ymax = l<cmin ? TMath::Pi()/2. : cosmics(l,cmin);
+  double ymin = l<cmax ? -1             : cosmics(l,cmax);
+  double y = marinTheta(x_min,x_max,y_min,y_max,x_mean,y_mean);
+  return int(l>cmin && y>ymin && y<ymax);
+}
+
 float deltaR2(float eta1, float phi1, float eta2, float phi2) {
     float deta = std::abs(eta1-eta2);
     float dphi = deltaPhi(phi1,phi2);

--- a/plotter/limeAtLngs/cuts-bkgonly.txt
+++ b/plotter/limeAtLngs/cuts-bkgonly.txt
@@ -2,4 +2,4 @@ clusters : sc_integral > 0
 runrange : (run>=1700 && run<=2300) || run>5000
 minenergy   : sc_integral > 5e2
 center : R(sc_xmean,sc_ymean)<800
-cosmicsveto : sc_width/sc_length>0.3 || abs(sc_theta)>40
+cosmicsveto : marinBand(sc_length,sc_xmin,sc_xmax,sc_ymin,sc_ymax,sc_xmean,sc_ymean)==0

--- a/plotter/limeAtLngs/plots-bkgonly.txt
+++ b/plotter/limeAtLngs/plots-bkgonly.txt
@@ -19,3 +19,5 @@ gslimness: sc_tgausssigma/sc_lgausssigma : 50,0,2 ; XTitle="#xi_{Gauss}"
 nhits: sc_nhits : 100,0,2e4 ; XTitle="n_{p}" , IncludeOverflows=False, Logy=True
 
 EvsL: sc_integral\:0.152*sc_length : 50,0,350,100,5e5,3e5; XTitle="length (mm)", YTitle="I_{SC} (photons)", Logy=True, Logx=True, Logz=True
+
+MvsL: marinTheta(sc_xmin,sc_xmax,sc_ymin,sc_ymax,sc_xmean,sc_ymean)\:0.152*sc_length : 200,0,350,200,0,1.6; XTitle="length (mm)", YTitle="#theta (rad)", Logz=True


### PR DESCRIPTION
Implement the cosmics veto as a function of Length vs Theta as in [this Davide Marin presentation](https://agenda.infn.it/event/31787/contributions/174101/attachments/92494/125948/Report.pdf)

Example of band removed by cosmics veto cut:

![image](https://user-images.githubusercontent.com/4517974/197202477-896ad006-da12-4ab8-ada9-e0ec2c146633.png)

@davidepinci 