### PR TITLE
Plotting stuff for the LIME performance paper

### DIFF
--- a/debug_code/plot_pickled_image.py
+++ b/debug_code/plot_pickled_image.py
@@ -19,6 +19,7 @@ if __name__ == '__main__':
     }
 
     suff = {'raw': 'oriIma',
+            '0th': '0th_3D',
             '1st': '1st_3D',
             '2nd': '2nd_3D',
             'all': 'all_3D',
@@ -26,28 +27,18 @@ if __name__ == '__main__':
             }
             
     
-    fig_handle = pl.load(open('pic_run0{run}_ev{ev}_{step}.pkl'.format(run=args[0],ev=args[1],step=suff[options.step]),'rb'))
+    fig_handle = pl.load(open('CAM0_{step}.pkl'.format(step=suff[options.step]),'rb'))
     plt.set_cmap(options.cmap)
     if options.step=='raw':
         plt.title('Image after zero suppression', font, pad=40)
         plt.xlabel('x (pixels)', font, labelpad=20)
         plt.ylabel('y (pixels)', font, labelpad=20)
         plt.clim(vmin=-5,vmax=10)
-        if int(args[0])==2317 and int(args[1])==8: ## example of split track
-            plt.clim(vmin=0,vmax=25)
-            csize = 160
-            plt.xlim(4*240,4*(240+csize))
-            plt.ylim(4*70,4*(70+csize))
-        elif int(args[0])==2097 and int(args[1])==317: # ambe 60/40 (6 keV NR candidate)
-            plt.clim(vmin=0,vmax=40)
-            csize = 100
-            plt.xlim(1200,1200+csize)
-            plt.ylim(880,880+csize)
-        elif int(args[0])==2097 and int(args[1])==59: # ambe 60/40 (6 keV NR candidate)
-            plt.clim(vmin=0,vmax=40)
-            csize = 100
-            plt.xlim(660,660+csize)
-            plt.ylim(1020,1020+csize)
+        plt.clim(vmin=0,vmax=25)
+        csize = 160
+        plt.xlim(1140,1275)
+        plt.ylim(1500,1640)
+
 
     else:
         plt.title('Rebinned image', font, pad=40)
@@ -72,6 +63,6 @@ if __name__ == '__main__':
     #plt.show()
 
     for ext in ['pdf','png']:
-        plt.savefig('pic_run0{run}_ev{ev}_{step}_paper.{ext}'.format(run=args[0],ev=args[1],step=suff[options.step],ext=ext))
+        plt.savefig('pic_{step}_paper.{ext}'.format(step=suff[options.step],ext=ext))
     plt.gcf().clear()
     plt.close('all')

--- a/debug_code/plot_pickled_image.py
+++ b/debug_code/plot_pickled_image.py
@@ -19,7 +19,7 @@ if __name__ == '__main__':
     }
 
     suff = {'raw': 'oriIma',
-            '0th': '0th_3D',
+            '0th': '0th',
             '1st': '1st_3D',
             '2nd': '2nd_3D',
             'all': 'all_3D',
@@ -36,26 +36,25 @@ if __name__ == '__main__':
         plt.clim(vmin=-5,vmax=10)
         plt.clim(vmin=0,vmax=25)
         csize = 160
-        plt.xlim(1140,1275)
-        plt.ylim(1500,1640)
+        plt.ylim(250,2000)
+        #plt.xlim(1140,1275)
+        #plt.ylim(1500,1640)
 
 
     else:
         plt.title('Rebinned image', font, pad=40)
         plt.xlabel('x (macro-pixels)', font, labelpad=20)
         plt.ylabel('y (macro-pixels)', font, labelpad=20)
-        if int(args[0])==1843: ## iron
-            plt.clim(vmin=98,vmax=120)
-            csize = 60
-            plt.xlim(240,240+csize)
-            plt.ylim(170,170+csize)
-        elif int(args[0])==2317 and int(args[1])==8: ## example of split track
-            plt.clim(vmin=100,vmax=110)
-            csize = 160
-            plt.xlim(240,240+csize)
-            plt.ylim(70,70+csize)
-        elif int(args[0])==2156: # cosmics
-            plt.clim(vmin=98,vmax=110)            
+        plt.clim(vmin=0,vmax=25)
+        plt.ylim(62,500)
+        plt.gca().invert_yaxis()
+#        cmap = plt.cm.get_cmap("binary")
+#        reversed_color_map = cmap.reversed()
+        
+        csize = 160
+        #plt.xlim(1140,1275)
+        #plt.ylim(1500,1640)
+
             
     plt.xticks(fontsize=14)
     plt.yticks(fontsize=14)

--- a/pedestals/runlog_LNGS.csv
+++ b/pedestals/runlog_LNGS.csv
@@ -4764,3 +4764,662 @@ run_number , run_description , start_time , exposure_sec , GEM3_V , GEM2_V , GEM
 5904 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 13:49:11 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-02 13:53:44 , 402
 5905 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 13:55:46 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-02 14:00:18 , 402
 5906 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 14:02:20 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-02 14:06:54 , 401
+5907 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 14:08:56 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-02 14:13:29 , 401
+5910 , S003:DATA:55Fe at 25cm, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 14:50:10 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-02 14:55:05 , 406
+5911 , S003:DATA:55Fe at 25cm, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations -30, scan PMT HV , 2022-12-02 14:56:29 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 741 , 741 , 767 , 740 , 1 , 2022-12-02 15:01:15 , 406
+5912 , S003:DATA:55Fe at 25cm, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations -60 V, scan PMT HV , 2022-12-02 15:02:21 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 709 , 709 , 734 , 710 , 1 , 2022-12-02 15:08:05 , 492
+5913 , S003:DATA:55Fe at 25cm, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations -90 V, scan PMT HV , 2022-12-02 15:12:18 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 678 , 678 , 702 , 680 , 1 , 2022-12-02 15:17:18 , 435
+5914 , S003:DATA:55Fe at 25cm, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations -120 V, scan PMT HV , 2022-12-02 15:19:31 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 647 , 647 , 669 , 650 , 1 , 2022-12-02 15:24:19 , 420
+5915 , S003:DATA:55Fe at 25cm, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations -170 V, scan PMT HV , 2022-12-02 15:26:15 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 600 , 600 , 620 , 600 , 1 , 2022-12-02 15:30:49 , 406
+5918 , S003:DATA:55Fe at 25cm, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations -170 V, scan PMT HV , 2022-12-02 15:41:24 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 450 , 450 , 470 , 450 , 1 , 2022-12-02 15:42:02 , 53
+5919 , S003:DATA:55Fe at 25cm, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations -330 V, scan PMT HV , 2022-12-02 15:42:53 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 450 , 450 , 470 , 450 , 1 , 2022-12-02 15:47:33 , 405
+5920 , S003:DATA:55Fe at 25cm, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations -430 V, scan PMT HV , 2022-12-02 15:48:39 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 350 , 350 , 370 , 350 , 1 , 2022-12-02 15:49:13 , 0
+5921 , S003:DATA:55Fe at 25cm, with pmt Trg: LVL2, 250mV thr, veto 10 us, flux 10l/h, new equalizations -20 V, HIGH Thr , 2022-12-02 15:57:40 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 752 , 752 , 780 , 750 , 1 , 2022-12-02 16:10:13 , 203
+5922 , S003:PED:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 16:33:28 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-02 16:34:24 , 104
+5923 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 16:37:08 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-02 16:41:44 , 404
+5924 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 16:43:46 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-02 16:48:17 , 401
+5925 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 16:50:21 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-02 16:54:54 , 401
+5926 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 16:56:56 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-02 17:01:28 , 402
+5927 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 17:03:30 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-02 17:08:03 , 401
+5930 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 17:18:41 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-02 17:23:14 , 401
+5931 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 17:25:17 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-02 17:29:48 , 401
+5932 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 17:31:50 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-02 17:36:22 , 402
+5933 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 17:38:24 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-02 17:42:57 , 401
+5934 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 17:44:59 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-02 17:49:32 , 401
+5935 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 17:51:35 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-02 17:56:08 , 402
+5936 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 17:58:10 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-02 18:02:43 , 402
+5937 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 18:04:46 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-02 18:09:20 , 401
+5938 , S003:PED:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 18:11:52 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-02 18:12:48 , 104
+5939 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 18:15:31 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-02 18:20:03 , 402
+5940 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 18:22:05 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-02 18:26:39 , 402
+5941 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 18:28:41 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-02 18:33:14 , 401
+5942 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 18:35:16 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-02 18:39:50 , 402
+5943 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 18:41:52 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-02 18:46:29 , 405
+5944 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 18:48:31 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-02 18:53:03 , 402
+5945 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 18:55:05 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-02 18:59:40 , 402
+5946 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 19:01:42 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-02 19:06:15 , 401
+5947 , S003:PED:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 19:08:46 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-02 19:09:43 , 105
+5948 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 19:12:27 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-02 19:17:02 , 405
+5949 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 19:19:04 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-02 19:23:35 , 402
+5950 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 19:25:37 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-02 19:30:08 , 401
+5951 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 19:32:10 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-02 19:36:44 , 402
+5952 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 19:38:46 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-02 19:43:19 , 402
+5953 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 19:45:21 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-02 19:49:54 , 401
+5954 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 19:51:56 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-02 19:56:31 , 401
+5955 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 19:58:33 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-02 20:03:10 , 405
+5956 , S003:PED:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 20:05:41 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-02 20:06:37 , 104
+5957 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 20:09:21 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-02 20:13:54 , 402
+5958 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 20:15:56 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-02 20:20:28 , 401
+5959 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 20:22:30 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-02 20:27:04 , 402
+5960 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 20:29:06 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-02 20:33:39 , 402
+5961 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 20:35:40 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-02 20:40:13 , 402
+5962 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 20:42:15 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-02 20:46:47 , 402
+5963 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 20:48:49 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-02 20:53:21 , 402
+5964 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 20:55:23 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-02 20:59:59 , 405
+5965 , S003:PED:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 21:02:30 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-02 21:03:26 , 104
+5966 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 21:06:10 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-02 21:10:44 , 402
+5967 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 21:12:46 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-02 21:17:20 , 401
+5968 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 21:19:22 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-02 21:23:55 , 402
+5969 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 21:25:57 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-02 21:30:33 , 405
+5970 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 21:32:35 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-02 21:37:08 , 401
+5971 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 21:39:10 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-02 21:43:42 , 401
+5972 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 21:45:44 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-02 21:50:16 , 401
+5974 , S003:PED:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 21:55:12 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-02 21:56:08 , 104
+5975 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 21:58:52 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-02 22:03:24 , 402
+5976 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 22:05:26 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-02 22:10:00 , 402
+5977 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 22:12:02 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-02 22:16:35 , 401
+5978 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 22:18:37 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-02 22:23:10 , 402
+5979 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 22:25:12 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-02 22:29:49 , 405
+5980 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 22:31:51 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-02 22:36:28 , 404
+5981 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 22:38:30 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-02 22:43:04 , 402
+5982 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 22:45:06 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-02 22:49:37 , 401
+5983 , S003:PED:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 22:52:09 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-02 22:53:05 , 104
+5984 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 22:55:49 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-02 23:00:23 , 401
+5985 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 23:02:25 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-02 23:07:00 , 402
+5986 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 23:09:02 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-02 23:13:37 , 402
+5987 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 23:15:39 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-02 23:20:11 , 402
+5988 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 23:22:13 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-02 23:26:48 , 402
+5989 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 23:28:50 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-02 23:33:24 , 402
+5990 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 23:35:26 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-02 23:39:58 , 401
+5991 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 23:42:00 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-02 23:46:34 , 401
+5992 , S003:PED:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 23:49:05 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-02 23:50:01 , 104
+5993 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 23:52:46 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-02 23:57:20 , 401
+5994 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-02 23:59:22 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 00:03:58 , 405
+5995 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 00:06:00 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 00:10:32 , 402
+5996 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 00:12:34 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 00:17:07 , 401
+5997 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 00:19:09 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 00:23:43 , 401
+5998 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 00:25:44 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 00:30:18 , 402
+5999 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 00:32:20 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 00:36:55 , 402
+6000 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 00:38:57 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 00:43:31 , 401
+6001 , S003:PED:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 00:46:02 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-03 00:46:59 , 105
+6002 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 00:49:42 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 00:54:16 , 402
+6003 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 00:56:18 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 01:00:55 , 405
+6004 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 01:02:57 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 01:07:33 , 405
+6005 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 01:09:35 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 01:14:06 , 402
+6006 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 01:16:08 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 01:20:43 , 402
+6007 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 01:22:45 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 01:27:17 , 401
+6008 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 01:29:19 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 01:33:53 , 402
+6009 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 01:35:55 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 01:40:27 , 402
+6010 , S003:PED:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 01:42:59 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-03 01:43:55 , 104
+6011 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 01:46:39 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 01:51:12 , 402
+6012 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 01:53:14 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 01:57:46 , 401
+6013 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 01:59:48 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 02:04:22 , 401
+6014 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 02:06:24 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 02:10:59 , 402
+6015 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 02:13:00 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 02:17:34 , 402
+6016 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 02:19:36 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 02:24:09 , 401
+6017 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 02:26:11 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 02:30:45 , 402
+6018 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 02:32:47 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 02:37:22 , 402
+6019 , S003:PED:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 02:39:54 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-03 02:40:50 , 104
+6020 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 02:43:34 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 02:48:08 , 402
+6021 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 02:50:10 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 02:54:44 , 402
+6022 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 02:56:46 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 03:01:19 , 402
+6023 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 03:03:21 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 03:07:54 , 402
+6024 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 03:09:56 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 03:14:31 , 402
+6025 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 03:16:33 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 03:21:07 , 402
+6026 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 03:23:09 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 03:27:41 , 401
+6027 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 03:29:43 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 03:34:16 , 402
+6028 , S003:PED:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 03:36:47 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-03 03:37:44 , 105
+6029 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 03:40:28 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 03:45:01 , 402
+6030 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 03:47:03 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 03:51:35 , 401
+6031 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 03:53:37 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 03:58:13 , 405
+6032 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 04:00:15 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 04:04:50 , 402
+6033 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 04:06:52 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 04:11:27 , 402
+6034 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 04:13:29 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 04:18:03 , 401
+6035 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 04:20:05 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 04:24:37 , 402
+6036 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 04:26:39 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 04:31:11 , 401
+6037 , S003:PED:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 04:33:42 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-03 04:34:38 , 104
+6038 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 04:37:22 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 04:41:56 , 401
+6039 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 04:43:58 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 04:48:32 , 402
+6040 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 04:50:34 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 04:55:07 , 401
+6041 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 04:57:09 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 05:01:46 , 404
+6042 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 05:03:48 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 05:08:22 , 402
+6043 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 05:10:24 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 05:14:56 , 402
+6044 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 05:16:58 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 05:21:32 , 401
+6045 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 05:23:34 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 05:28:07 , 402
+6046 , S003:PED:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 05:30:38 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-03 05:31:35 , 104
+6047 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 05:34:19 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 05:38:53 , 401
+6048 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 05:40:55 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 05:45:29 , 402
+6049 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 05:47:31 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 05:52:09 , 405
+6051 , S003:PED:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 06:23:27 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-03 06:24:23 , 104
+6052 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 06:27:07 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 06:31:41 , 402
+6053 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 06:33:43 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 06:38:17 , 401
+6054 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 06:40:19 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 06:44:56 , 404
+6055 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 06:46:58 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 06:51:31 , 401
+6056 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 06:53:33 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 06:58:08 , 402
+6057 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 07:00:11 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 07:04:45 , 402
+6058 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 07:06:47 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 07:11:21 , 402
+6059 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 07:13:23 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 07:18:00 , 405
+6060 , S003:PED:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 07:20:31 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-03 07:21:27 , 105
+6061 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 07:24:11 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 07:28:45 , 402
+6062 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 07:30:47 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 07:35:20 , 401
+6063 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 07:37:22 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 07:41:56 , 401
+6064 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 07:43:58 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 07:48:31 , 402
+6065 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 07:50:33 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 07:55:06 , 402
+6066 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 07:57:08 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 08:01:41 , 401
+6067 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 08:03:43 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 08:08:18 , 402
+6068 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 08:10:19 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 08:14:53 , 402
+6069 , S003:PED:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 08:17:24 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-03 08:18:21 , 105
+6070 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 08:21:04 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 08:25:37 , 402
+6071 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 08:27:39 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 08:32:16 , 405
+6072 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 08:34:18 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 08:38:52 , 401
+6073 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 08:40:54 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 08:45:29 , 402
+6074 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 08:47:30 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 08:52:04 , 402
+6075 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 08:54:06 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 08:58:41 , 401
+6076 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 09:00:43 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 09:05:16 , 401
+6077 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 09:07:18 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 09:11:52 , 402
+6078 , S003:PED:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 09:14:23 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-03 09:15:20 , 106
+6079 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 09:18:04 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 09:22:39 , 402
+6080 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 09:24:41 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 09:29:14 , 402
+6081 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 09:31:16 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 09:35:50 , 401
+6082 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 09:37:52 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 09:42:27 , 402
+6083 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 09:44:28 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 09:49:04 , 405
+6084 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 09:51:06 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 09:55:39 , 402
+6085 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 09:57:41 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 10:02:14 , 401
+6086 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 10:04:16 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 10:08:49 , 402
+6087 , S003:PED:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 10:11:21 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-03 10:12:17 , 104
+6088 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 10:15:01 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 10:19:36 , 401
+6089 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 10:21:38 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 10:26:12 , 402
+6090 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 10:28:14 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 10:32:47 , 402
+6091 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 10:34:49 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 10:39:23 , 401
+6092 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 10:41:25 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 10:45:57 , 401
+6093 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 10:47:59 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 10:52:33 , 402
+6094 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 10:54:35 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 10:59:09 , 402
+6095 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 11:01:11 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 11:05:46 , 402
+6096 , S003:PED:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 11:08:17 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-03 11:09:13 , 104
+6097 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 11:11:58 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 11:16:30 , 402
+6098 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 11:18:32 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 11:23:11 , 405
+6099 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 11:25:13 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 11:29:47 , 402
+6100 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 11:31:49 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 11:36:22 , 401
+6101 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 11:38:24 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 11:42:59 , 401
+6102 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 11:45:01 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 11:49:35 , 401
+6103 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 11:51:37 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 11:56:14 , 405
+6104 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 11:58:16 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 12:02:51 , 401
+6105 , S003:PED:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 12:05:22 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-03 12:06:19 , 105
+6106 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 12:09:02 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 12:13:39 , 404
+6107 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 12:15:42 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 12:20:16 , 402
+6108 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 12:22:18 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 12:26:52 , 401
+6109 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 12:28:54 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 12:33:29 , 402
+6110 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 12:35:31 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 12:40:05 , 402
+6111 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 12:42:07 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 12:46:42 , 402
+6112 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 12:48:44 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 12:53:18 , 401
+6113 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 12:55:20 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 12:59:53 , 401
+6114 , S003:PED:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 13:02:24 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-03 13:03:21 , 104
+6115 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 13:06:05 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 13:10:40 , 401
+6116 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 13:12:42 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 13:17:17 , 401
+6117 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 13:19:19 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 13:23:52 , 402
+6118 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 13:25:54 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 13:30:28 , 402
+6119 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 13:32:30 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 13:37:04 , 401
+6120 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 13:39:06 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 13:43:40 , 401
+6121 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 13:45:42 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 13:50:15 , 402
+6122 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 13:52:17 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 13:56:53 , 402
+6123 , S003:PED:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 13:59:24 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-03 14:00:21 , 105
+6124 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 14:03:04 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 14:07:39 , 401
+6125 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 14:09:42 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 14:14:20 , 405
+6126 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 14:16:22 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 14:20:56 , 401
+6127 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 14:22:57 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 14:27:33 , 402
+6128 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 14:29:35 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 14:34:10 , 402
+6129 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 14:36:13 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 14:40:47 , 402
+6130 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 14:42:49 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 14:47:24 , 402
+6131 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 14:49:26 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 14:53:59 , 401
+6132 , S003:PED:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 14:56:31 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-03 14:57:27 , 104
+6133 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 15:00:11 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 15:04:44 , 402
+6134 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 15:06:45 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 15:11:18 , 401
+6135 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 15:13:20 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 15:17:54 , 401
+6136 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 15:19:56 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 15:24:28 , 401
+6137 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 15:26:30 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 15:31:04 , 401
+6138 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 15:33:06 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 15:37:39 , 401
+6139 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 15:39:41 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 15:44:16 , 402
+6140 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 15:46:18 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 15:50:50 , 401
+6141 , S003:PED:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 15:53:22 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-03 15:54:19 , 104
+6142 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 15:57:02 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 16:01:39 , 405
+6143 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 16:03:41 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 16:08:17 , 405
+6144 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 16:10:20 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 16:14:54 , 402
+6145 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 16:16:56 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 16:21:29 , 402
+6146 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 16:23:31 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 16:28:05 , 401
+6147 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 16:30:07 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 16:34:41 , 401
+6148 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 16:36:43 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 16:41:16 , 401
+6149 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 16:43:19 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 16:47:54 , 402
+6150 , S003:PED:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 16:50:25 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-03 16:51:21 , 104
+6151 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 16:54:06 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 16:58:38 , 402
+6152 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 17:00:40 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 17:05:13 , 402
+6153 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 17:07:15 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 17:11:48 , 401
+6154 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 17:13:50 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 17:18:26 , 401
+6155 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 17:20:28 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 17:25:01 , 401
+6156 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 17:27:03 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 17:31:37 , 402
+6157 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 17:33:39 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 17:38:11 , 402
+6158 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 17:40:13 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 17:44:45 , 402
+6159 , S003:PED:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 17:47:16 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-03 17:48:12 , 104
+6160 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 17:50:56 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 17:55:29 , 402
+6161 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 17:57:31 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 18:02:06 , 401
+6162 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 18:04:08 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 18:08:42 , 405
+6163 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 18:10:44 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 18:15:18 , 402
+6164 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 18:17:20 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 18:21:54 , 401
+6165 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 18:23:56 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 18:28:31 , 402
+6166 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 18:30:33 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 18:35:07 , 402
+6167 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 18:37:09 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 18:41:44 , 401
+6168 , S003:PED:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 18:44:15 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-03 18:45:12 , 106
+6169 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 18:47:56 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 18:52:30 , 402
+6170 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 18:54:32 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 18:59:09 , 405
+6171 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 19:01:13 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 19:05:47 , 402
+6172 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 19:07:49 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 19:12:22 , 402
+6173 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 19:14:24 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 19:18:59 , 401
+6174 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 19:21:01 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 19:25:35 , 401
+6175 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 19:27:37 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 19:32:11 , 402
+6176 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 19:34:13 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 19:38:47 , 402
+6177 , S003:PED:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 19:41:18 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-03 19:42:14 , 104
+6178 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 19:44:58 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 19:49:32 , 401
+6179 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 19:51:34 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 19:56:07 , 402
+6180 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 19:58:09 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 20:02:44 , 402
+6181 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 20:04:46 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 20:09:19 , 401
+6182 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 20:11:21 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 20:15:57 , 405
+6183 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 20:17:59 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 20:22:36 , 405
+6184 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 20:24:38 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 20:29:13 , 402
+6185 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 20:31:15 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 20:35:51 , 401
+6186 , S003:PED:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 20:38:23 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-03 20:39:19 , 104
+6187 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 20:42:03 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 20:46:37 , 402
+6188 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 20:48:39 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 20:53:13 , 401
+6189 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 20:55:15 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 20:59:51 , 405
+6190 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 21:01:53 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 21:06:28 , 402
+6191 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 21:08:30 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 21:13:04 , 402
+6192 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 21:15:06 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 21:19:40 , 402
+6193 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 21:21:42 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 21:26:16 , 401
+6194 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 21:28:18 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 21:32:56 , 405
+6195 , S003:PED:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 21:35:27 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-03 21:36:24 , 105
+6196 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 21:39:07 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 21:43:42 , 402
+6197 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 21:45:44 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 21:50:23 , 405
+6198 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 21:52:26 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 21:57:00 , 402
+6199 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 21:59:02 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 22:03:36 , 402
+6200 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 22:05:38 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 22:10:15 , 402
+6201 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 22:12:17 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 22:16:51 , 401
+6202 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 22:18:53 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 22:23:27 , 401
+6203 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 22:25:29 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 22:30:05 , 403
+6204 , S003:PED:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 22:32:36 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-03 22:33:33 , 106
+6205 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 22:36:17 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 22:40:51 , 401
+6206 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 22:42:53 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 22:47:26 , 402
+6207 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 22:49:29 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 22:54:04 , 402
+6208 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 22:56:06 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 23:00:43 , 405
+6209 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 23:02:45 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 23:07:19 , 401
+6210 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 23:09:21 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 23:13:57 , 405
+6211 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 23:15:59 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 23:20:35 , 402
+6212 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 23:22:37 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 23:27:15 , 404
+6213 , S003:PED:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 23:29:45 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-03 23:30:42 , 105
+6214 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 23:33:26 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 23:38:00 , 401
+6215 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 23:40:02 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 23:44:36 , 402
+6216 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 23:46:38 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 23:51:11 , 402
+6217 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 23:53:13 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-03 23:57:50 , 405
+6218 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-03 23:59:52 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 00:04:30 , 405
+6219 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-04 00:06:32 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 00:11:09 , 403
+6220 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-04 00:13:11 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 00:17:44 , 401
+6221 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-04 00:19:46 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 00:24:22 , 402
+6222 , S003:PED:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-04 00:26:53 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-04 00:27:50 , 104
+6223 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-04 00:30:34 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 00:35:09 , 401
+6224 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-04 00:37:11 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 00:41:46 , 402
+6225 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-04 00:43:48 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 00:48:23 , 401
+6226 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-04 00:50:25 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 00:55:03 , 405
+6227 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-04 00:57:05 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 01:01:41 , 402
+6228 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-04 01:03:43 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 01:08:21 , 405
+6229 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-04 01:10:23 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 01:15:01 , 405
+6230 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-04 01:17:03 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 01:21:36 , 402
+6231 , S003:PED:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-04 01:24:07 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-04 01:25:04 , 104
+6232 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-04 01:27:48 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 01:32:21 , 401
+6233 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-04 01:34:23 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 01:39:01 , 404
+6234 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-04 01:41:03 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 01:45:38 , 402
+6235 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-04 01:47:40 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 01:52:14 , 402
+6236 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-04 01:54:16 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 01:58:51 , 402
+6237 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-04 02:00:53 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 02:05:26 , 402
+6238 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-04 02:07:28 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 02:12:06 , 405
+6239 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-04 02:14:08 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 02:18:41 , 401
+6240 , S003:PED:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-04 02:21:12 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-04 02:22:08 , 104
+6241 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-04 02:24:52 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 02:29:27 , 402
+6242 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-04 02:31:29 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 02:36:03 , 402
+6243 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-04 02:38:06 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 02:42:42 , 401
+6244 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-04 02:44:45 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 02:49:20 , 402
+6245 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-04 02:51:22 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 02:55:56 , 401
+6246 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-04 02:57:58 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 03:02:31 , 401
+6247 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-04 03:04:33 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 03:09:08 , 401
+6248 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-04 03:11:10 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 03:15:45 , 402
+6249 , S003:PED:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-04 03:18:16 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-04 03:19:13 , 105
+6250 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-04 03:21:56 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 03:26:32 , 402
+6251 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-04 03:28:34 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 03:33:16 , 405
+6252 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-04 03:35:18 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 03:39:52 , 401
+6253 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-04 03:41:54 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 03:46:29 , 402
+6254 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-04 03:48:31 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 03:53:06 , 402
+6255 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-04 03:55:08 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 03:59:43 , 401
+6256 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-04 04:01:46 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 04:06:20 , 401
+6257 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-04 04:08:22 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 04:12:56 , 402
+6258 , S003:PED:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-04 04:15:27 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-04 04:16:23 , 104
+6259 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-04 04:19:07 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 04:23:42 , 402
+6260 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-04 04:25:44 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 04:30:19 , 401
+6261 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-04 04:32:21 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 04:36:55 , 402
+6262 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-04 04:38:57 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 04:43:31 , 401
+6263 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-04 04:45:33 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 04:50:10 , 405
+6264 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-04 04:52:12 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 04:56:49 , 403
+6265 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-04 04:58:52 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 05:03:28 , 402
+6266 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-04 05:05:30 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 05:10:08 , 405
+6267 , S003:PED:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-04 05:12:39 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-04 05:13:35 , 104
+6268 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-04 05:16:19 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 05:20:53 , 401
+6269 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-04 05:22:55 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 05:27:30 , 401
+6270 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-04 05:29:32 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 05:34:10 , 404
+6271 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-04 05:36:12 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 05:40:48 , 402
+6272 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-04 05:42:50 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 05:47:28 , 404
+6273 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-04 05:49:30 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 05:54:05 , 402
+6274 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-04 05:56:07 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 06:00:42 , 401
+6275 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-04 06:02:45 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 06:07:20 , 405
+6276 , S003:PED:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-04 06:09:52 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-04 06:10:48 , 104
+6277 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-04 06:13:32 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 06:18:08 , 401
+6278 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-04 06:20:10 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 06:24:44 , 401
+6279 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-04 06:26:46 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 06:31:19 , 402
+6280 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-04 06:33:21 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 06:37:54 , 402
+6281 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-04 06:39:56 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 06:44:31 , 402
+6282 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-04 06:46:33 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 06:51:07 , 402
+6283 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-04 06:53:09 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 06:57:45 , 401
+6284 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-04 06:59:47 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 07:04:22 , 401
+6285 , S003:PED:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-04 07:06:54 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-04 07:07:50 , 104
+6286 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-04 07:10:34 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 07:15:09 , 402
+6287 , S003:DATA:BKG, with pmt Trg: LVL2, 2mV thr, veto 10 us, flux 10l/h, new equalizations , 2022-12-04 07:17:11 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 08:44:58 , 0
+6288 , S003:PED:BKG, no PMT, with pmt, flux 10l/h , 2022-12-04 08:57:04 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-04 08:57:59 , 101
+6289 , S003:PED:BKG, no PMT, flux 10l/h , 2022-12-04 09:00:58 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-04 09:01:54 , 104
+6290 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 09:04:38 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 09:08:12 , 405
+6291 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 09:10:14 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 09:13:48 , 405
+6292 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 09:15:50 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 09:19:23 , 404
+6293 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 09:21:25 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 09:24:59 , 405
+6294 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 09:27:01 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 09:30:35 , 404
+6295 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 09:32:36 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 09:36:11 , 406
+6296 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 09:38:12 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 09:41:46 , 405
+6297 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 09:43:48 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 09:47:21 , 404
+6298 , S003:PED:BKG, no PMT, flux 10l/h , 2022-12-04 09:49:51 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-04 09:50:47 , 104
+6299 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 09:53:31 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 09:57:04 , 404
+6300 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 09:59:06 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 10:02:40 , 405
+6301 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 10:04:42 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 10:08:15 , 404
+6302 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 10:10:17 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 10:13:51 , 405
+6303 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 10:15:53 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 10:19:26 , 404
+6304 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 10:21:28 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 10:25:02 , 405
+6305 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 10:27:04 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 10:30:37 , 404
+6306 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 10:32:39 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 10:36:13 , 405
+6307 , S003:PED:BKG, no PMT, flux 10l/h , 2022-12-04 10:38:44 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-04 10:39:41 , 106
+6308 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 10:42:24 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 10:45:58 , 406
+6309 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 10:48:01 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 10:51:34 , 404
+6310 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 10:53:37 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 10:57:11 , 404
+6311 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 10:59:12 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 11:02:46 , 405
+6312 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 11:04:48 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 11:08:22 , 405
+6313 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 11:10:24 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 11:13:57 , 404
+6314 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 11:15:59 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 11:19:33 , 405
+6315 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 11:21:35 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 11:25:09 , 404
+6316 , S003:PED:BKG, no PMT, flux 10l/h , 2022-12-04 11:27:40 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-04 11:28:34 , 101
+6317 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 11:31:17 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 11:34:52 , 406
+6318 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 11:36:54 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 11:40:28 , 404
+6319 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 11:42:30 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 11:46:04 , 404
+6320 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 11:48:05 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 11:51:39 , 405
+6321 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 11:53:41 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 11:57:14 , 404
+6322 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 11:59:16 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 12:02:50 , 405
+6323 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 12:04:52 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 12:08:26 , 405
+6324 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 12:10:28 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 12:14:01 , 404
+6325 , S003:PED:BKG, no PMT, flux 10l/h , 2022-12-04 12:16:33 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-04 12:17:29 , 105
+6326 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 12:20:13 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 12:23:46 , 404
+6327 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 12:25:48 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 12:29:22 , 405
+6328 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 12:31:24 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 12:34:57 , 404
+6329 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 12:36:59 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 12:40:33 , 405
+6330 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 12:42:35 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 12:46:09 , 404
+6331 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 12:48:10 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 12:51:44 , 406
+6332 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 12:53:46 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 12:57:20 , 405
+6333 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 12:59:22 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 13:02:56 , 405
+6334 , S003:PED:BKG, no PMT, flux 10l/h , 2022-12-04 13:05:28 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-04 13:06:23 , 104
+6335 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 13:09:08 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 13:12:41 , 404
+6336 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 13:14:43 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 13:18:17 , 405
+6337 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 13:20:19 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 13:23:52 , 404
+6338 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 13:25:54 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 13:29:28 , 405
+6339 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 13:31:30 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 13:35:05 , 404
+6340 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 13:37:06 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 13:40:41 , 406
+6341 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 13:42:42 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 13:46:16 , 406
+6342 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 13:48:18 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 13:51:52 , 405
+6343 , S003:PED:BKG, no PMT, flux 10l/h , 2022-12-04 13:54:24 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-04 13:55:19 , 104
+6344 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 13:58:04 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 14:01:38 , 404
+6345 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 14:03:39 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 14:07:13 , 405
+6346 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 14:09:15 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 14:12:48 , 404
+6347 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 14:14:50 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 14:18:24 , 405
+6348 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 14:20:26 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 14:23:59 , 404
+6349 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 14:26:01 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 14:29:35 , 405
+6350 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 14:31:37 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 14:35:10 , 404
+6351 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 14:37:12 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 14:40:46 , 405
+6352 , S003:PED:BKG, no PMT, flux 10l/h , 2022-12-04 14:43:17 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-04 14:44:13 , 105
+6353 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 14:46:58 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 14:50:31 , 404
+6354 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 14:52:33 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 14:56:07 , 405
+6355 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 14:58:09 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 15:01:42 , 404
+6356 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 15:03:44 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 15:07:18 , 405
+6357 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 15:09:20 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 15:12:54 , 405
+6358 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 15:14:56 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 15:18:29 , 404
+6359 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 15:20:31 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 15:24:05 , 405
+6360 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 15:26:07 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 15:29:40 , 404
+6361 , S003:PED:BKG, no PMT, flux 10l/h , 2022-12-04 15:32:11 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-04 15:33:08 , 106
+6362 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 15:35:52 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 15:39:25 , 404
+6363 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 15:41:27 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 15:45:01 , 405
+6364 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 15:47:03 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 15:50:37 , 404
+6365 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 15:52:38 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 15:56:12 , 405
+6366 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 15:58:14 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 16:01:48 , 405
+6367 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 16:03:50 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 16:07:24 , 405
+6368 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 16:09:26 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 16:12:59 , 404
+6369 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 16:15:01 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 16:18:35 , 405
+6370 , S003:PED:BKG, no PMT, flux 10l/h , 2022-12-04 16:21:06 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-04 16:22:02 , 106
+6371 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 16:24:46 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 16:28:20 , 406
+6372 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 16:30:22 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 16:33:56 , 405
+6373 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 16:35:58 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 16:39:31 , 404
+6374 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 16:41:33 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 16:45:07 , 405
+6375 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 16:47:09 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 16:50:43 , 405
+6376 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 16:52:45 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 16:56:18 , 404
+6377 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 16:58:20 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 17:01:54 , 405
+6378 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 17:03:56 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 17:07:29 , 404
+6379 , S003:PED:BKG, no PMT, flux 10l/h , 2022-12-04 17:10:00 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-04 17:10:54 , 102
+6380 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 17:13:38 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 17:17:12 , 405
+6381 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 17:19:14 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 17:22:48 , 404
+6382 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 17:24:49 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 17:28:23 , 406
+6383 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 17:30:25 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 17:33:59 , 405
+6384 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 17:36:01 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 17:39:34 , 404
+6385 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 17:41:36 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 17:45:10 , 405
+6386 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 17:47:14 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 17:50:49 , 406
+6387 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 17:52:51 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 17:56:24 , 404
+6388 , S003:PED:BKG, no PMT, flux 10l/h , 2022-12-04 17:58:55 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-04 17:59:49 , 101
+6389 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 18:02:32 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 18:06:06 , 406
+6390 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 18:08:08 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 18:11:42 , 405
+6391 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 18:13:44 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 18:17:18 , 405
+6392 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 18:19:20 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 18:22:53 , 404
+6393 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 18:24:55 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 18:28:29 , 405
+6394 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 18:30:31 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 18:34:04 , 404
+6395 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 18:36:06 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 18:39:40 , 405
+6396 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 18:41:42 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 18:45:16 , 404
+6397 , S003:PED:BKG, no PMT, flux 10l/h , 2022-12-04 18:47:46 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-04 18:48:40 , 101
+6398 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 18:51:24 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 18:54:58 , 405
+6399 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 18:57:00 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 19:00:33 , 404
+6400 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 19:02:35 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 19:06:09 , 405
+6401 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 19:08:12 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 19:11:45 , 404
+6402 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 19:13:47 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 19:17:21 , 405
+6403 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 19:19:23 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 19:22:57 , 404
+6404 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 19:24:58 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 19:28:33 , 406
+6405 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 19:30:34 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 19:34:08 , 405
+6406 , S003:PED:BKG, no PMT, flux 10l/h , 2022-12-04 19:36:39 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-04 19:37:36 , 105
+6407 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 19:40:20 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 19:43:53 , 404
+6408 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 19:45:55 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 19:49:29 , 405
+6409 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 19:51:31 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 19:55:04 , 404
+6410 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 19:57:06 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 20:00:40 , 405
+6411 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 20:02:42 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 20:06:16 , 404
+6412 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 20:08:17 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 20:11:51 , 406
+6413 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 20:13:53 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 20:17:27 , 405
+6414 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 20:19:29 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 20:23:03 , 405
+6415 , S003:PED:BKG, no PMT, flux 10l/h , 2022-12-04 20:25:34 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-04 20:26:30 , 105
+6416 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 20:29:15 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 20:32:49 , 404
+6417 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 20:34:50 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 20:38:25 , 406
+6418 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 20:40:26 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 20:44:00 , 406
+6419 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 20:46:02 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 20:49:36 , 405
+6420 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 20:51:38 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 20:55:12 , 404
+6421 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 20:57:13 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 21:00:48 , 406
+6422 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 21:02:49 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 21:06:24 , 406
+6423 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 21:08:25 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 21:11:59 , 405
+6424 , S003:PED:BKG, no PMT, flux 10l/h , 2022-12-04 21:14:30 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-04 21:15:27 , 104
+6425 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 21:18:11 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 21:21:45 , 405
+6426 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 21:23:47 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 21:27:21 , 405
+6427 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 21:29:23 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 21:32:56 , 404
+6428 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 21:34:58 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 21:38:32 , 405
+6429 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 21:40:34 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 21:44:07 , 404
+6430 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 21:46:09 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 21:49:43 , 405
+6431 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 21:51:45 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 21:55:19 , 404
+6432 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 21:57:20 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 22:00:55 , 406
+6433 , S003:PED:BKG, no PMT, flux 10l/h , 2022-12-04 22:03:25 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-04 22:04:22 , 106
+6434 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 22:07:06 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 22:10:39 , 404
+6435 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 22:12:41 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 22:16:15 , 405
+6436 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 22:18:17 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 22:21:51 , 404
+6437 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 22:23:52 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 22:27:26 , 405
+6438 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 22:29:28 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 22:33:02 , 405
+6439 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 22:35:04 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 22:38:38 , 404
+6440 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 22:40:40 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 22:44:13 , 404
+6441 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 22:46:15 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 22:49:49 , 405
+6442 , S003:PED:BKG, no PMT, flux 10l/h , 2022-12-04 22:52:20 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-04 22:53:16 , 105
+6443 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 22:56:00 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 22:59:34 , 405
+6444 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 23:01:36 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 23:05:10 , 405
+6445 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 23:07:12 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 23:10:45 , 404
+6446 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 23:12:47 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 23:16:21 , 405
+6447 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 23:18:23 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 23:21:56 , 404
+6448 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 23:23:58 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 23:27:32 , 405
+6449 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 23:29:34 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 23:33:07 , 404
+6450 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 23:35:09 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 23:38:43 , 405
+6451 , S003:PED:BKG, no PMT, flux 10l/h , 2022-12-04 23:41:14 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-04 23:42:10 , 106
+6452 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 23:44:54 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 23:48:28 , 405
+6453 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 23:50:30 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 23:54:03 , 404
+6454 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-04 23:56:05 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-04 23:59:39 , 405
+6455 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 00:01:41 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 00:05:14 , 404
+6456 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 00:07:16 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 00:10:50 , 405
+6457 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 00:12:52 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 00:16:26 , 405
+6458 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 00:18:28 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 00:22:01 , 404
+6459 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 00:24:03 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 00:27:37 , 405
+6460 , S003:PED:BKG, no PMT, flux 10l/h , 2022-12-05 00:30:08 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-05 00:31:04 , 106
+6461 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 00:33:48 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 00:37:22 , 405
+6462 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 00:39:24 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 00:42:57 , 404
+6463 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 00:44:59 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 00:48:33 , 405
+6464 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 00:50:35 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 00:54:09 , 405
+6465 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 00:56:11 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 00:59:45 , 404
+6466 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 01:01:47 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 01:05:20 , 404
+6469 , S003:PED:BKG, no PMT, flux 10l/h , 2022-12-05 01:21:05 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-05 01:22:02 , 106
+6470 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 01:24:45 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 01:28:19 , 406
+6471 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 01:30:21 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 01:33:55 , 405
+6472 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 01:35:57 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 01:39:30 , 404
+6473 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 01:41:32 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 01:45:06 , 405
+6474 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 01:47:08 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 01:50:41 , 404
+6475 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 01:52:43 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 01:56:17 , 405
+6476 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 01:58:19 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 02:01:53 , 404
+6477 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 02:03:54 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 02:07:29 , 406
+6478 , S003:PED:BKG, no PMT, flux 10l/h , 2022-12-05 02:09:59 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-05 02:10:53 , 101
+6479 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 02:13:37 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 02:17:10 , 404
+6480 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 02:19:12 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 02:22:46 , 405
+6481 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 02:24:48 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 02:28:21 , 404
+6482 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 02:30:23 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 02:33:57 , 405
+6483 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 02:35:59 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 02:39:33 , 405
+6484 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 02:41:35 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 02:45:08 , 404
+6485 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 02:47:10 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 02:50:44 , 405
+6486 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 02:52:46 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 02:56:19 , 404
+6487 , S003:PED:BKG, no PMT, flux 10l/h , 2022-12-05 02:58:50 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-05 02:59:44 , 101
+6488 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 03:02:27 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 03:06:01 , 406
+6489 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 03:08:03 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 03:11:37 , 405
+6490 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 03:13:39 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 03:17:12 , 404
+6491 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 03:19:14 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 03:22:48 , 405
+6492 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 03:24:50 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 03:28:24 , 404
+6493 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 03:30:25 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 03:33:59 , 406
+6494 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 03:36:01 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 03:39:35 , 405
+6495 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 03:41:37 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 03:45:10 , 404
+6496 , S003:PED:BKG, no PMT, flux 10l/h , 2022-12-05 03:47:41 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-05 03:48:38 , 106
+6497 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 03:51:21 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 03:54:55 , 406
+6498 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 03:56:57 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 04:00:31 , 405
+6499 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 04:02:33 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 04:06:07 , 404
+6500 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 04:08:09 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 04:11:42 , 404
+6501 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 04:13:44 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 04:17:18 , 405
+6502 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 04:19:20 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 04:22:54 , 405
+6503 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 04:24:56 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 04:28:30 , 404
+6504 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 04:30:31 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 04:34:05 , 406
+6505 , S003:PED:BKG, no PMT, flux 10l/h , 2022-12-05 04:36:36 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-05 04:37:29 , 101
+6506 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 04:40:14 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 04:43:47 , 404
+6507 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 04:45:49 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 04:49:23 , 405
+6508 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 04:51:25 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 04:54:58 , 404
+6509 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 04:57:00 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 05:00:34 , 405
+6510 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 05:02:36 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 05:06:09 , 404
+6511 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 05:08:11 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 05:11:45 , 405
+6512 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 05:13:47 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 05:17:20 , 404
+6513 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 05:19:22 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 05:22:56 , 405
+6514 , S003:PED:BKG, no PMT, flux 10l/h , 2022-12-05 05:25:26 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-05 05:26:20 , 101
+6515 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 05:29:04 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 05:32:38 , 405
+6516 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 05:34:40 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 05:38:14 , 404
+6517 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 05:40:15 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 05:43:49 , 406
+6518 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 05:45:51 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 05:49:25 , 405
+6519 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 05:51:27 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 05:55:00 , 404
+6520 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 05:57:02 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 06:00:36 , 405
+6521 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 06:02:38 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 06:06:13 , 404
+6522 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 06:08:15 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 06:11:49 , 404
+6523 , S003:PED:BKG, no PMT, flux 10l/h , 2022-12-05 06:14:19 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-05 06:15:13 , 101
+6524 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 06:17:57 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 06:21:30 , 404
+6525 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 06:23:32 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 06:27:06 , 405
+6526 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 06:29:08 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 06:32:41 , 404
+6527 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 06:34:43 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 06:38:17 , 405
+6528 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 06:40:19 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 06:43:53 , 405
+6529 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 06:45:55 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 06:49:29 , 404
+6530 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 06:51:30 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 06:55:04 , 406
+6531 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 06:57:06 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 07:00:40 , 405
+6532 , S003:PED:BKG, no PMT, flux 10l/h , 2022-12-05 07:03:11 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-05 07:04:07 , 105
+6533 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 07:06:51 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 07:10:25 , 405
+6534 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 07:12:27 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 07:16:00 , 401
+6535 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 07:18:02 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 07:21:36 , 405
+6536 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 07:23:38 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 07:27:12 , 404
+6537 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 07:29:14 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 07:32:47 , 404
+6538 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 07:34:49 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 07:38:23 , 405
+6539 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 07:40:25 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 07:43:58 , 404
+6541 , S003:PED:BKG, no PMT, flux 10l/h , 2022-12-05 08:52:57 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-05 08:53:53 , 105
+6542 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 08:56:37 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 09:00:11 , 405
+6543 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 09:02:13 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 09:05:47 , 405
+6544 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 09:07:49 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 09:11:22 , 404
+6545 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 09:13:24 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 09:16:58 , 405
+6546 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 09:19:00 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 09:22:33 , 404
+6547 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 09:24:35 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 09:28:09 , 405
+6548 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 09:30:11 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 09:33:44 , 404
+6549 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 09:35:46 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 09:39:20 , 405
+6550 , S003:PED:BKG, no PMT, flux 10l/h , 2022-12-05 09:41:51 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-05 09:42:47 , 106
+6551 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 09:45:31 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 09:49:05 , 405
+6552 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 09:51:07 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 09:54:40 , 404
+6553 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 09:56:42 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 10:00:16 , 405
+6554 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 10:02:18 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 10:05:52 , 404
+6555 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 10:07:54 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 10:11:28 , 404
+6556 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 10:13:30 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 10:17:03 , 404
+6557 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 10:19:05 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 10:22:39 , 405
+6558 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 10:24:41 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 10:28:14 , 404
+6559 , S003:PED:BKG, no PMT, flux 10l/h , 2022-12-05 10:30:45 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-05 10:31:42 , 106
+6560 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 10:34:25 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 10:38:00 , 406
+6561 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 10:40:01 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 10:43:35 , 405
+6562 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 10:45:37 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 10:49:11 , 404
+6563 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 10:51:13 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 10:54:47 , 404
+6564 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 10:56:49 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 11:00:22 , 404
+6565 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 11:02:24 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 11:05:58 , 405
+6566 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 11:08:00 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 11:11:34 , 404
+6567 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 11:13:35 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 11:17:09 , 406
+6568 , S003:PED:BKG, no PMT, flux 10l/h , 2022-12-05 11:19:40 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 0 , 2022-12-05 11:20:34 , 101
+6569 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 11:23:18 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 11:26:52 , 404
+6570 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 11:28:53 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 11:32:27 , 404
+6571 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 11:34:29 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 11:38:03 , 405
+6572 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 11:40:05 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 11:43:38 , 404
+6573 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 11:45:40 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 11:49:14 , 405
+6574 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 11:51:16 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 11:54:49 , 404
+6575 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 11:56:51 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 12:00:25 , 405
+6576 , S003:DATA:BKG, no PMT, flux 10l/h , 2022-12-05 12:02:27 , 0.3 , 420 , 420 , 420 , 500 , 500 , 960 , 0 , 772 , 772 , 800 , 770 , 1 , 2022-12-05 12:06:01 , 404

--- a/plotter/functions.cc
+++ b/plotter/functions.cc
@@ -58,6 +58,11 @@ int marinBand(double length, double x_min, double x_max, double y_min, double y_
   return int(l>cmin && y>ymin && y<ymax);
 }
 
+float calib_energy(double uncalib) {
+  float photon2kev = 0.00075;
+  return photon2kev * uncalib;
+}
+
 float deltaR2(float eta1, float phi1, float eta2, float phi2) {
     float deta = std::abs(eta1-eta2);
     float dphi = deltaPhi(phi1,phi2);

--- a/plotter/limeAtLnf/cuts-bkgonly.txt
+++ b/plotter/limeAtLnf/cuts-bkgonly.txt
@@ -1,0 +1,6 @@
+clusters : sc_integral > 0
+#runrange : (run>=1700 && run<=2300) || run>5000
+minenergy   : sc_integral > 5e2
+center : R(sc_xmean,sc_ymean)<800
+cosmicsveto : marinBand(sc_length,sc_xmin,sc_xmax,sc_ymin,sc_ymax,sc_xmean,sc_ymean)==0
+short : 0.152*sc_length < 80

--- a/plotter/limeAtLnf/cuts-bkgonly.txt
+++ b/plotter/limeAtLnf/cuts-bkgonly.txt
@@ -1,6 +1,6 @@
 clusters : sc_integral > 0
 #runrange : (run>=1700 && run<=2300) || run>5000
-minenergy   : sc_integral > 5e2
+minenergy   : sc_integral > 0
 center : R(sc_xmean,sc_ymean)<800
 cosmicsveto : marinBand(sc_length,sc_xmin,sc_xmax,sc_ymin,sc_ymax,sc_xmean,sc_ymean)==0
 short : 0.152*sc_length < 80

--- a/plotter/limeAtLnf/mca-bkgonly.txt
+++ b/plotter/limeAtLnf/mca-bkgonly.txt
@@ -1,4 +1,4 @@
-bkg    : reco_bkgtofe_26cm : 1933. ; FillColor=ROOT.kBlue+1, FillStyle=3004, Label="No source" 
+bkg    : reco_bkgtofe_26cm : 1 ; FillColor=ROOT.kBlue+1, FillStyle=3004, Label="No source" 
 fakes+ : reco_pedestals : 1 ; FillColor=ROOT.kRed+1, Label="Fakes"
 
 data   : reco_fe_26cm : 1 ; FillColor=ROOT.kRed+1, Label="Source"

--- a/plotter/limeAtLnf/mca-bkgonly.txt
+++ b/plotter/limeAtLnf/mca-bkgonly.txt
@@ -1,0 +1,4 @@
+bkg    : reco_bkgtofe_26cm : 1933. ; FillColor=ROOT.kBlue+1, FillStyle=3004, Label="No source" 
+fakes+ : reco_pedestals : 1 ; FillColor=ROOT.kRed+1, Label="Fakes"
+
+data   : reco_fe_26cm : 1 ; FillColor=ROOT.kRed+1, Label="Source"

--- a/plotter/limeAtLnf/plots-bkgonly.txt
+++ b/plotter/limeAtLnf/plots-bkgonly.txt
@@ -1,20 +1,28 @@
-raw_integral_anyrange:   sc_integral    : 100,5e2,3e5 ; XTitle="I_{SC} (photons)", IncludeOverflows=True
+raw_integral_anyrange:   sc_integral    : 100,5e2,3e5 ; XTitle="I_{SC} (photons)", IncludeOverflows=True, Logy=True
 
-raw_integral_highrange:  sc_integral    : 100,5e3,3e5 ; XTitle="I_{SC} (photons)", IncludeOverflows=False
+raw_integral_highrange:  sc_integral    : 100,5e3,3e5 ; XTitle="I_{SC} (photons)", IncludeOverflows=True
 
 raw_integral_lowrange:   sc_integral    : 100,5e2,2e4 ; XTitle="I_{SC} (photons)", IncludeOverflows=False
 
-raw_integral_normrange:   sc_integral    : 100,0,4e3 ; XTitle="I_{SC} (photons)", IncludeOverflows=False
+raw_integral_normrange:  sc_integral    : 100,0,3e3 ; XTitle="I_{SC} (photons)", IncludeOverflows=False
 
-density:                 sc_integral/sc_nhits : 50,0,50 ; XTitle="#delta (photons/pixels)", IncludeOverflows=False
+cal_integral_anyrange:   calib_energy(sc_integral)    : 100,0,225 ; XTitle="E_{SC} (keV)", IncludeOverflows=True, Logy=True
 
-rms:    sc_rms : 50,0,20 ; XTitle="rms (photons)", IncludeOverflows=False
+cal_integral_highrange:  calib_energy(sc_integral)    : 100,15,225 ; XTitle="I_{SC} (keV)", IncludeOverflows=True
 
-length: 0.152 * sc_length : 50,0,350 ; XTitle="length (mm)", IncludeOverflows=False, Logy=True
+cal_integral_lowrange:   calib_energy(sc_integral)    : 100,0.5,15 ; XTitle="I_{SC} (keV)", IncludeOverflows=False
+
+cal_integral_normrange:  calib_energy(sc_integral)    : 100,0,2 ; XTitle="I_{SC} (keV)", IncludeOverflows=False
+
+density:                 sc_integral/sc_nhits : 50,0,50 ; XTitle="#delta (photons/pixels)", IncludeOverflows=True
+
+rms:    sc_rms : 50,0,20 ; XTitle="rms (photons)", IncludeOverflows=True
+
+length: 0.152 * sc_length : 50,0,350 ; XTitle="length (mm)", IncludeOverflows=True, Logy=True
 
 width:  0.152 * sc_width : 50,0,20 ; XTitle="width (mm)", IncludeOverflows=False
 
-tgausssigma: 0.152 * sc_tgausssigma : 50,0,3 ; XTitle="#sigma_{T}^{Gauss} (mm)", IncludeOverflows=False
+tgausssigma: 0.152 * sc_tgausssigma : 50,0,3 ; XTitle="#sigma_{T}^{Gauss} (mm)", IncludeOverflows=True
 
 slimness: sc_width/sc_length : 50,0,1 ; XTitle="#xi"
 

--- a/plotter/limeAtLnf/plots-bkgonly.txt
+++ b/plotter/limeAtLnf/plots-bkgonly.txt
@@ -1,0 +1,27 @@
+raw_integral_anyrange:   sc_integral    : 100,5e2,3e5 ; XTitle="I_{SC} (photons)", IncludeOverflows=True
+
+raw_integral_highrange:  sc_integral    : 100,5e3,3e5 ; XTitle="I_{SC} (photons)", IncludeOverflows=False
+
+raw_integral_lowrange:   sc_integral    : 100,5e2,2e4 ; XTitle="I_{SC} (photons)", IncludeOverflows=False
+
+raw_integral_normrange:   sc_integral    : 100,0,4e3 ; XTitle="I_{SC} (photons)", IncludeOverflows=False
+
+density:                 sc_integral/sc_nhits : 50,0,50 ; XTitle="#delta (photons/pixels)", IncludeOverflows=False
+
+rms:    sc_rms : 50,0,20 ; XTitle="rms (photons)", IncludeOverflows=False
+
+length: 0.152 * sc_length : 50,0,350 ; XTitle="length (mm)", IncludeOverflows=False, Logy=True
+
+width:  0.152 * sc_width : 50,0,20 ; XTitle="width (mm)", IncludeOverflows=False
+
+tgausssigma: 0.152 * sc_tgausssigma : 50,0,3 ; XTitle="#sigma_{T}^{Gauss} (mm)", IncludeOverflows=False
+
+slimness: sc_width/sc_length : 50,0,1 ; XTitle="#xi"
+
+gslimness: sc_tgausssigma/sc_lgausssigma : 50,0,2 ; XTitle="#xi_{Gauss}"
+
+nhits: sc_nhits : 100,0,2e4 ; XTitle="n_{p}" , IncludeOverflows=False, Logy=True
+
+EvsL: sc_integral\:0.152*sc_length : 50,0,350,100,5e5,3e5; XTitle="length (mm)", YTitle="I_{SC} (photons)", Logy=True, Logx=True, Logz=True
+
+MvsL: marinTheta(sc_xmin,sc_xmax,sc_ymin,sc_ymax,sc_xmean,sc_ymean)\:0.152*sc_length : 200,0,350,200,0,1.6; XTitle="length (mm)", YTitle="#theta (rad)", Logz=True

--- a/plotter/limeAtLngs/cuts-bkgonly.txt
+++ b/plotter/limeAtLngs/cuts-bkgonly.txt
@@ -3,3 +3,4 @@ runrange : (run>=1700 && run<=2300) || run>5000
 minenergy   : sc_integral > 5e2
 center : R(sc_xmean,sc_ymean)<800
 cosmicsveto : marinBand(sc_length,sc_xmin,sc_xmax,sc_ymin,sc_ymax,sc_xmean,sc_ymean)==0
+short : 0.152*sc_length < 80

--- a/plotter/limeAtLngs/plots-bkgonly.txt
+++ b/plotter/limeAtLngs/plots-bkgonly.txt
@@ -1,3 +1,5 @@
+raw_integral_anyrange:   sc_integral    : 100,5e2,3e5 ; XTitle="I_{SC} (photons)", IncludeOverflows=True
+
 raw_integral_highrange:  sc_integral    : 100,5e3,3e5 ; XTitle="I_{SC} (photons)", IncludeOverflows=False
 
 raw_integral_lowrange:   sc_integral    : 50,5e2,1e4 ; XTitle="I_{SC} (photons)", IncludeOverflows=False

--- a/plotter/mcAnalysis.py
+++ b/plotter/mcAnalysis.py
@@ -212,13 +212,9 @@ class MCAnalysis:
                     if not os.path.exists(countersfile):
                         print ("Warning: counters.txt file not present. Assuming no skim and taking the process normalization from file for component %s" % cnames)
                         ## get the counts from the histograms instead of pickle file (smart, but extra load for ROOT from EOS it seems)
-                        ROOT.gEnv.SetValue("TFile.AsyncReading", 1);
-                        tmp_rootfile = ROOT.TFile.Open(rootfile+"?readaheadsz=65535")
-                        tmp_tree     = tmp_rootfile.Get('Events')
+                        total_w += sum(tty.getEntries() for tty in self._allData[pname])
                         is_w = 0
-                        total_w += tmp_tree.GetEntries()
                         scale = "(%s)" % field[2]
-                        tmp_rootfile.Close()
                     else:
                         countersobj  = open(countersfile, "r")
                         counters = eval(countersobj.read())
@@ -274,8 +270,8 @@ class MCAnalysis:
                     myvariations[0].name = "norm_"+tty.getOption('PegNormToProcess')
                     print("Overwrite the norm systematic for %s to make it correlated with %s" % (pname, tty.getOption('PegNormToProcess')))
                 if pname not in self._rank: self._rank[pname] = len(self._rank)
-            if to_norm: 
-                for tty in ttys: tty.setScaleFactor("%s*%g" % (scale, 1.0/total_w))
+            if to_norm:
+                for tty in ttys: tty.setScaleFactor("%s" % scale)
             for tty in ttys: tty.makeTTYVariations()
         data_entries = sum(tty.getEntries() for tty in self._allData['data'])
         for p in self.listProcesses():

--- a/plotter/mcAnalysis.py
+++ b/plotter/mcAnalysis.py
@@ -212,14 +212,13 @@ class MCAnalysis:
                     if not os.path.exists(countersfile):
                         print ("Warning: counters.txt file not present. Assuming no skim and taking the process normalization from file for component %s" % cnames)
                         ## get the counts from the histograms instead of pickle file (smart, but extra load for ROOT from EOS it seems)
-                        total_w += sum(tty.getEntries() for tty in self._allData[pname])
+                        ROOT.gEnv.SetValue("TFile.AsyncReading", 1);
+                        tmp_rootfile = ROOT.TFile.Open(rootfile+"?readaheadsz=65535")
+                        tmp_tree     = tmp_rootfile.Get('Events')
                         is_w = 0
-<<<<<<< HEAD
                         total_w += tmp_tree.GetEntries()
-                        print ("total w = ",total_w)
-=======
->>>>>>> origin/summer22
                         scale = "(%s)" % field[2]
+                        tmp_rootfile.Close()
                     else:
                         countersobj  = open(countersfile, "r")
                         counters = eval(countersobj.read())
@@ -245,10 +244,7 @@ class MCAnalysis:
                 else:
                     print("Poorly formatted line: ", field)
                     raise RuntimeError
-<<<<<<< HEAD
-=======
-                
->>>>>>> origin/summer22
+
                 # Adjust free-float and fixed from command line
                 for p0 in options.processesToFloat:
                     for p in p0.split(","):
@@ -278,13 +274,8 @@ class MCAnalysis:
                     myvariations[0].name = "norm_"+tty.getOption('PegNormToProcess')
                     print("Overwrite the norm systematic for %s to make it correlated with %s" % (pname, tty.getOption('PegNormToProcess')))
                 if pname not in self._rank: self._rank[pname] = len(self._rank)
-<<<<<<< HEAD
             if to_norm: 
                 for tty in ttys: tty.setScaleFactor("%s*%g" % (scale, 1.0/total_w))
-=======
-            if to_norm:
-                for tty in ttys: tty.setScaleFactor("%s" % scale)
->>>>>>> origin/summer22
             for tty in ttys: tty.makeTTYVariations()
         data_entries = sum(tty.getEntries() for tty in self._allData['data'])
         for p in self.listProcesses():

--- a/plotter/mcPlots.py
+++ b/plotter/mcPlots.py
@@ -366,7 +366,7 @@ def doNormFit(pspec,pmap,mca,saveScales=False):
     ROOT.RooMsgService.instance().setGlobalKillBelow(gKill)
     return postfit
 
-def doRatioHists(pspec,pmap,total,maxRange,fixRange=False,fitRatio=None,errorsOnRef=True,ratioNums="signal",ratioDen="background",ylabel="Data/pred.",yndiv=505,doWide=False,showStatTotLegend=False,textSize=0.035):
+def doRatioHists(pspec,pmap,total,maxRange,fixRange=False,fitRatio=None,errorsOnRef=True,ratioNums="signal",ratioDen="background",ylabel="Data/pred.",yndiv=505,doWide=False,showStatTotLegend=False,showStatLegend=False,textSize=0.035):
     numkeys = [ "data" ]
     if "data" not in pmap: 
         if len(pmap) >= 2 and ratioDen in pmap:
@@ -467,7 +467,7 @@ def doRatioHists(pspec,pmap,total,maxRange,fixRange=False,fitRatio=None,errorsOn
     unity.GetXaxis().SetLabelOffset(0.015)
     unity.GetYaxis().SetNdivisions(yndiv)
     unity.GetYaxis().SetTitleFont(42)
-    unity.GetYaxis().SetTitleSize(0.14)
+    unity.GetYaxis().SetTitleSize(0.11)
     offset = 0.32 if doWide else 0.62
     unity.GetYaxis().SetTitleOffset(offset)
     unity.GetYaxis().SetLabelFont(42)
@@ -500,7 +500,7 @@ def doRatioHists(pspec,pmap,total,maxRange,fixRange=False,fitRatio=None,errorsOn
     line.Draw("L")
     for ratio in ratios:
         ratio.Draw("E SAME" if ratio.ClassName() != "TGraphAsymmErrors" else "PZ SAME");
-    leg0 = ROOT.TLegend(0.12 if doWide else 0.2, 0.84, 0.25 if doWide else 0.45, 0.94)
+    leg0 = ROOT.TLegend(0.12 if doWide else 0.2, 0.80, 0.25 if doWide else 0.45, 0.90)
     leg0.SetFillColor(0)
     leg0.SetShadowColor(0)
     leg0.SetLineColor(0)
@@ -508,14 +508,14 @@ def doRatioHists(pspec,pmap,total,maxRange,fixRange=False,fitRatio=None,errorsOn
     leg0.SetTextSize(textSize*0.7/0.3)
     leg0.AddEntry(unityErr0, "stat. unc.", "F")
     if showStatTotLegend: leg0.Draw()
-    leg1 = ROOT.TLegend(0.25 if doWide else 0.45, 0.84, 0.38 if doWide else 0.7, 0.94)
+    leg1 = ROOT.TLegend(0.25 if doWide else 0.45, 0.80, 0.38 if doWide else 0.7, 0.90)
     leg1.SetFillColor(0)
     leg1.SetShadowColor(0)
     leg1.SetLineColor(0)
     leg1.SetTextFont(42)
     leg1.SetTextSize(textSize*0.7/0.3)
     leg1.AddEntry(unityErr, "total unc.", "F")
-    if showStatTotLegend: leg1.Draw()
+    if showStatLegend: leg1.Draw()
     global legendratio0_, legendratio1_
     legendratio0_ = leg0
     legendratio1_ = leg1
@@ -1015,7 +1015,7 @@ class PlotMaker:
                     p2.cd(); 
                     rdata,rnorm,rnorm2,rline = doRatioHists(pspec,pmap,total, maxRange=options.maxRatioRange, fixRange=options.fixRatioRange,
                                                             fitRatio=options.fitRatio, errorsOnRef=options.errorBandOnRatio, 
-                                                            ratioNums=options.ratioNums, ratioDen=options.ratioDen, ylabel=options.ratioYLabel, yndiv=options.ratioYNDiv, doWide=doWide, showStatTotLegend=options.showStatTotLegend, textSize=options.legendFontSize)
+                                                            ratioNums=options.ratioNums, ratioDen=options.ratioDen, ylabel=options.ratioYLabel, yndiv=options.ratioYNDiv, doWide=doWide, showStatTotLegend=options.showStatTotLegend, showStatLegend=options.showStatLegend,textSize=options.legendFontSize)
                 if self._options.printPlots:
                     for ext in self._options.printPlots.split(","):
                         fdir = printDir;
@@ -1136,7 +1136,7 @@ def addPlotMakerOptions(parser, addAlsoMCAnalysis=True):
     if addAlsoMCAnalysis: addMCAnalysisOptions(parser)
     parser.add_option("--ss",  "--scale-signal", dest="signalPlotScale", default=1.0, type="float", help="scale the signal in the plots by this amount");
     #parser.add_option("--lspam", dest="lspam",   type="string", default="CMS Simulation", help="Spam text on the right hand side");
-    parser.add_option("--lspam", dest="lspam",   type="string", default="#bf{CYGNO} #it{Preliminary}", help="Spam text on the right hand side");
+    parser.add_option("--lspam", dest="lspam",   type="string", default="#bf{CYGNO}", help="Spam text on the right hand side");
     parser.add_option("--rspam", dest="rspam",   type="string", default="(LIME)", help="Spam text on the right hand side");
     parser.add_option("--addspam", dest="addspam", type = "string", default=None, help="Additional spam text on the top left side, in the frame");
     parser.add_option("--topSpamSize", dest="topSpamSize",   type="float", default=1.2, help="Zoom factor for the top spam");
@@ -1155,6 +1155,7 @@ def addPlotMakerOptions(parser, addAlsoMCAnalysis=True):
     parser.add_option("--ratioYLabel", dest="ratioYLabel", type="string", default="Data/pred.", help="Y axis label of the ratio histogram.")
     parser.add_option("--ratioYNDiv", dest="ratioYNDiv", type="int", default=505, help="Y axis divisions in the ratio histogram.")
     parser.add_option("--noErrorBandOnRatio", dest="errorBandOnRatio", action="store_false", default=True, help="Do not show the error band on the reference in the ratio plots")
+    parser.add_option("--noStatLegendOnRatio", dest="showStatLegend", action="store_false", default=True, help="Do not show the stat entry in the legend in the ratio plots")
     parser.add_option("--noStatTotLegendOnRatio", dest="showStatTotLegend", action="store_false", default=True, help="Do not show the legend in the ratio plots")
     parser.add_option("--attachRatioPanel", dest="attachRatioPanel", action="store_true", default=False, help="Attach the ratio panel to the main plot, without a white spacer in between")
     parser.add_option("--fitRatio", dest="fitRatio", type="int", default=None, help="Fit the ratio with a polynomial of the specified order")

--- a/reconstruction.py
+++ b/reconstruction.py
@@ -2,7 +2,7 @@ from concurrent import futures
 from subprocess import Popen, PIPE
 import signal,time
 
-import os,math,sys,random,re
+import os,math,sys,random,re,gc
 import numpy as np
 
 import ROOT
@@ -298,7 +298,6 @@ class analysis:
             tf = sw.swift_read_root_file(self.tmpname)
             keys = tf.keys()
             mf = [0] # dummy array to make a common loop with MIDAS case
-            import gc
         else:
             run,tmpdir,tag = self.tmpname
             mf = sw.swift_download_midas_file(run,tmpdir,tag)
@@ -346,7 +345,6 @@ class analysis:
                 if event in self.options.excImages: justSkip=True
                 if self.options.debug_mode == 1 and event != self.options.ev: justSkip=True
                 if justSkip:
-                    if obj.any(): del obj
                     continue
                 
                 if camera==True:
@@ -410,7 +408,7 @@ class analysis:
                         if self.options.type in ['beam','cosmics']: algo = 'HOUGH'
                         snprod_inputs = {'picture': img_rb_zs, 'pictureHD': img_fr_satcor, 'picturezsHD': img_fr_zs, 'pictureOri': img_fr, 'vignette': self.vignmap, 'name': name, 'algo': algo}
                         plotpy = self.options.jobs < 2 # for some reason on macOS this crashes in multicore
-                        snprod_params = {'snake_qual': 3, 'plot2D': False, 'plotpy': False, 'plotprofiles': False}
+                        snprod_params = {'snake_qual': 3, 'plot2D': False, 'plotpy': False, 'plotprofiles': True}
                         snprod = SnakesProducer(snprod_inputs,snprod_params,self.options,self.cg)
                         snakes = snprod.run()
                         self.autotree.fillCameraVariables(img_fr_zs)

--- a/reconstruction.py
+++ b/reconstruction.py
@@ -408,7 +408,7 @@ class analysis:
                         if self.options.type in ['beam','cosmics']: algo = 'HOUGH'
                         snprod_inputs = {'picture': img_rb_zs, 'pictureHD': img_fr_satcor, 'picturezsHD': img_fr_zs, 'pictureOri': img_fr, 'vignette': self.vignmap, 'name': name, 'algo': algo}
                         plotpy = self.options.jobs < 2 # for some reason on macOS this crashes in multicore
-                        snprod_params = {'snake_qual': 3, 'plot2D': False, 'plotpy': False, 'plotprofiles': True}
+                        snprod_params = {'snake_qual': 3, 'plot2D': False, 'plotpy': False, 'plotprofiles': False}
                         snprod = SnakesProducer(snprod_inputs,snprod_params,self.options,self.cg)
                         snakes = snprod.run()
                         self.autotree.fillCameraVariables(img_fr_zs)

--- a/snakes.py
+++ b/snakes.py
@@ -244,15 +244,17 @@ class SnakesFactory:
                 fig = plt.figure(figsize=(self.options.figsizeX, self.options.figsizeY))
                 plt.imshow(self.image,cmap=self.options.cmapcolor,vmin=vmin, vmax=vmax,origin='lower' )
                 plt.title("Polynomial clusters found in iteration 0")
-                colorpix = np.zeros([rescale,rescale,3])
+                colorpix = np.ones([rescale,rescale,3]) * [255,255,255]
                 for j in range(0,np.shape(clu)[0]):
 
                     a = np.random.rand(3)
                     colorpix[clu[j][:,0],clu[j][:,1]] = a
                     
-                plt.imshow(colorpix,cmap='gray',origin='lower' )
+                plt.imshow(colorpix,cmap='binary',origin='lower' )
                 for ext in ['png','pdf']:
                     plt.savefig('{pdir}/{name}_{esp}_{tip}.{ext}'.format(pdir=outname, name=self.name, esp='0th', ext=ext, tip=self.options.tip), bbox_inches='tight', pad_inches=0)
+                with open('{pdir}/{name}_{esp}.pkl'.format(pdir=outname,name=self.name,esp='0th'), "wb") as fp:
+                    pickle.dump(fig, fp, protocol=4)
 
                 plt.gcf().clear()
                 plt.close('all')

--- a/utilities.py
+++ b/utilities.py
@@ -5,7 +5,14 @@ import os,sys,optparse,csv,resource
 import numpy as np
 import ROOT,math,uproot
 import swiftlib as sw
+import matplotlib.pyplot as plt            
 from cameraChannel import cameraTools, cameraGeometry
+
+font = {'family': 'arial',
+        'color':  'black',
+        'weight': 'normal',
+        'size': 24,
+        }
 
 class utils:
     def __init__(self):
@@ -86,6 +93,7 @@ class utils:
         N = cg.npixx
         nx=int(N/rebin); ny=int(N/rebin);
         normmap = ROOT.TH2D('normmap_{det}'.format(det=det),'normmap',nx,0,N,nx,0,N)
+        summap = normmap.Clone('summap_{det}'.format(det=det))
         
         mapsum = np.zeros((nx,nx))
 
@@ -117,7 +125,7 @@ class utils:
             #img_cimax = np.where(arr < 300, arr, 0)
             img_cimax = arr
             img_fr_sub = ctools.pedsub(img_cimax,pedarr_fr)
-            img_fr_zs  = ctools.zsfullres(img_fr_sub,noisearr_fr,nsigma=1)*1e-8
+            img_fr_zs  = ctools.zsfullres(img_fr_sub,noisearr_fr,nsigma=1)
             
             # for lime, remove the borders of the sensor
             if det=='lime':
@@ -148,9 +156,11 @@ class utils:
         for ix in range(nx):
             for iy in range(nx):
                 normmap.SetBinContent(ix+1,iy+1,min(mapnorm[ix,iy],1.));
+                summap.SetBinContent(ix+1,iy+1,mapsum[ix,iy]);
      
         tf_out.cd()
         normmap.Write()
+        summap.Write()
         tf_out.Close()
         print("Written the mean map with rebinning {rb}x{rb} into file {outf}.".format(rb=rebin,outf=outfile))
 
@@ -225,6 +235,17 @@ class utils:
         vignettemap_stretched.Write()        
         vign1d.Write()
         tf_out.Close()
+
+    def plotVignetteMap(self,filein,name='summap_lime'):
+        tf = uproot.open(filein)
+        vignette = np.rot90(tf[name].values())
+        fig = plt.figure(figsize=(12,12))
+        plt.imshow(vignette,cmap='binary',origin='upper',vmin=350,vmax=800 )
+        plt.xlabel('x (pixels)', font, labelpad=20)
+        plt.ylabel('y (pixels)', font, labelpad=20)
+        plt.ylim(250,2000)
+        plt.gca().invert_yaxis()
+        plt.savefig('%s.pdf' % name)
         
     def setPedestalRun(self,options,detector):
         if not hasattr(options,"pedrun"):
@@ -272,10 +293,14 @@ if __name__ == "__main__":
         run = 5890
         pedfile = 'pedestals/pedmap_run5861_rebin1.root'
         ut = utils()
-        ut.calcVignettingMap(run,pedfile,"vignette_run%05d.root" % run,det='lime',rebin=8,maxImages=1000)
+        ut.calcVignettingMap(run,pedfile,"vignette_run%05d.root" % run,det='lime',rebin=8,maxImages=10000)
 
     if options.make == 'vignette1d':
         ut = utils()
         ut.getVignette1D('vignette_run04117.root')
+
+    if options.make == 'plotVignette':
+        ut = utils()
+        ut.plotVignetteMap("vignette_run05890.root","summap_lime")
 
         


### PR DESCRIPTION
Several plotting stuff improvement. The only general and important one is commit a31c830263e3911b29efbd537ed8352c9aff8a51 that again fixes the normalization of the yields to the "data" component livetime, messed up by a merge done by mistake. 
