### PR TITLE
Fixed the image load from .mid to match the pedestal calculation

### DIFF
--- a/reconstruction.py
+++ b/reconstruction.py
@@ -325,6 +325,7 @@ class analysis:
                         run = int(m.group(1))
                         event = int(m.group(2))
                         obj = tf[key].values()
+                        #obj = np.rot90(obj)
                         camera=True
                     else:
                         camera=False
@@ -332,7 +333,7 @@ class analysis:
                     run = int(self.options.run)
                     if name.startswith('CAM'):
                         obj,_,_ = cy.daq_cam2array(mevent.banks[key])
-                        obj = np.rot90(obj,k=-1)
+                        obj = np.rot90(obj)
                         camera=True
                         numev += 1
                     else:


### PR DESCRIPTION
- Changing the rotation after image loading to match the pedestal subtraction rotation.
- Added a commented line with this same rotation on the image loading using .root, for those who create .root simulated runs using .mid files as pedestals (so they can use the same pedestal created from the .mid file).