### PR TITLE
Add h5 input format for simulated images

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,23 +28,19 @@ or *histograms_Run01515.root* if it was already a root file.
 
 
 
-## Running the analysis code on MC data (updated on December 2021):
-Firstly, create pedestal map (example with pedestal run 4159):
-1. set `justPedestal` to `True` in `configFile_MC.txt`
-2. add this line to `pedestals/pedruns_MC.txt`: `(4159, 4159) :   4159,`
-3. copy pedestal root file (`histograms_Run04159.root`) to `/tmp/<username>`  
-4. create pedmap with: `python reconstruction.py configFile_MC.txt -r 4159`
+## Running the analysis code on MC data (updated on June 2023):
+Firstly, create pedestal map (example with pedestal run 4904 of LNGS):
+1. set `justPedestal` to `True` in `configFile_LNGS.txt`
+2. create pedmap with: `python3 reconstruction.py configFile_LNGS.txt -r 4904`
  
-Now, you should have the file `pedestals/pedmap_run4159_rebin1.root`
+Now, you should have the file `pedestals/pedmap_run4904_rebin1.root`
 
-Secondly, reconstruct digitized images (example with 3 root input files):
-1. set `justPedestal` to `False` and `debug_mode` to `0` in `configFile_MC.txt`
-2. rename the 3 root input files: `histograms_Run00001.root`, `histograms_Run00002.root` and `histograms_Run00003.root` 
-3. create the directory `./input` and copy the 3 root input files in it
-4. add to `configFile_MC.txt`: `'tmpdir'  : './input/',`
-5. set right pedestal for run 1 to 3 in `pedestals/pedruns_MC.txt`: `(1,3) :   4159,`
-6. run in batch: `python scripts/submit_batch.py --outdir out/ --cfg configFile_MC.txt $(pwd) '[1-3]'`
+Then, reconstruct digitized (simulated) images:
+1. set `justPedestal` to `False` (and `debug_mode` to `0`) in `configFile_MC.txt`
+2. if needed, create the file `pedestals/runlog_MC.csv` with the script `scripts/make_runlog_tmp.py`. If the pedestal run is 4904, the simulated runs must be named with higher run numbers (4905, 4906 ...)
+3. move the simulated runs in the input directory `/path/to/inputdir/` and recostruct them with:
 
+`python3 reconstruction.py configFile_MC.txt -r 4905 -t /path/to/inputdir/`
 
 
 

--- a/configFile_MC.txt
+++ b/configFile_MC.txt
@@ -1,15 +1,18 @@
 {
+# DATA FORMAT
+'rawdata_tier' : 'h5',
+
 # DETECTOR
 'geometry'  : 'lime',
 
 # DEBUG plots
-'debug_mode'            : 1,
-'ev'                    : 53,
+'debug_mode'            : 0,
+'ev'                    : 52,
 'nclu'                  : -1,        # -1
 
 # Plots that will be made if debug_mode = 1
 
-'flag_full_image'       : 0,
+'flag_full_image'       : 1,
 'flag_rebin_image'      : 1,
 'flag_edges_image'      : 1,
 'flag_polycluster'      : 1,
@@ -28,7 +31,8 @@
 'numPedEvents'          : -1,
 'pedExclRegion'         : None,
 'rebin'                 : 4,
-'nsigma'                : 1.2,
+'nsigma'                : 0.9,
+'min_neighbors_average' : 1.1,                   # cut on the minimum average energy around a pixel (remove isolated macro-pixels)
 'cimax'                 : 5000,                    # Upper threshold (keep very high not to kill large signals)
 'justPedestal'          : False,
 'daq'                   : 'midas',                 # DAQ type (btf/h5/midas)
@@ -37,10 +41,9 @@
 'vignetteCorr'          : True,                    # apply vignetting correction (correction maps in data/ according to the geometry)
 
 'excImages'             : [], #list(range(5))+[],      # To exlude some images of the analysis. Always exclude the first 5 which are messy (not true anymore)
-'min_neighbors_average' : 0.75,                   # cut on the minimum average energy around a pixel (remove isolated macro-pixels)
 'donotremove'           : True,                   # Remove or not the file from the tmp folder
 
-'scfullinfo'            : True,			   # If True some the supercluster pixels info will be saved
+'scfullinfo'            : False,			   # If True some the supercluster pixels info will be saved
 'save_MC_data'          : False,			   # If True save the MC informations
 
 'tip'                   : '3D',

--- a/pedestals/runlog_MC.csv
+++ b/pedestals/runlog_MC.csv
@@ -1,0 +1,3 @@
+run_number , run_description , start_time , exposure_sec , GEM3_V , GEM2_V , GEM1_V , T2_V , T1_V , DRIFT_V , OFFSET_V , PMT1_V , PMT2_V , PMT3_V , PMT4_V , HV_STATE , total_gas_flow , stop_time , number_of_events , storage_local_status
+4904 , S000:PED:BKG, no pmt , 2022-06-08 18:51:02 , 0.5 , 430 , 430 , 430 , 500 , 500 , 1000 , 10 , 850 , 850 , 850 , 850 , 0 , NULL , 2022-06-08 18:58:32 , 302 , 0
+4905 , S000:DATA:BKG, no pmt , 2022-06-08 18:59:40 , 0.5 , 430 , 430 , 430 , 500 , 500 , 1000 , 10 , 850 , 850 , 850 , 850 , 1 , NULL , 2022-06-08 19:23:31 , 100 , 0

--- a/reconstruction.py
+++ b/reconstruction.py
@@ -10,6 +10,8 @@ ROOT.gROOT.SetBatch(True)
 import uproot
 from cameraChannel import cameraTools, cameraGeometry
 import midas.file_reader
+import h5py
+
 
 from snakes import SnakesProducer
 from output import OutputTree
@@ -113,6 +115,11 @@ class analysis:
         if options.rawdata_tier == 'root':
             tf = sw.swift_read_root_file(self.tmpname)
             pics = [k for k in tf.keys() if 'pic' in k]
+            return len(pics)
+        elif options.rawdata_tier == 'h5':
+            hf = sw.swift_read_h5_file(self.tmpname)
+            pics = [k for k in hf.keys() if 'pic' in k]
+            print("n events:", len(pics))
             return len(pics)
         else:
             run,tmpdir,tag = self.tmpname
@@ -301,6 +308,12 @@ class analysis:
             tf = sw.swift_read_root_file(self.tmpname)
             keys = tf.keys()
             mf = [0] # dummy array to make a common loop with MIDAS case
+        elif self.options.rawdata_tier == 'h5':
+            hf = sw.swift_read_h5_file(self.tmpname)
+            keys = hf.keys()
+            print(keys)
+            mf = [0] # dummy array to make a common loop with MIDAS case
+
         else:
             run,tmpdir,tag = self.tmpname
             mf = sw.swift_download_midas_file(run,tmpdir,tag)
@@ -330,6 +343,21 @@ class analysis:
                         camera=True
                     else:
                         camera=False
+                elif self.options.rawdata_tier == 'h5':
+                    if 'pic' in name:
+                        patt = re.compile('\S+run(\d+)_ev(\d+)')
+                        m = patt.match(name)
+                        run = int(m.group(1))
+                        event = int(m.group(2))
+                        print(key)
+                        print(hf[key])
+                        obj = np.array(hf[key])
+                        print(obj.shape)
+                        #obj = np.rot90(obj)
+                        camera=True
+                    else:
+                        camera=False
+
                 elif self.options.rawdata_tier == 'midas':
                     run = int(self.options.run)
                     if name.startswith('CAM'):
@@ -537,6 +565,9 @@ if __name__ == '__main__':
         if options.rawdata_tier=='root':
             prefix = 'histograms_Run'
             postfix = 'root'
+        elif options.rawdata_tier=='h5':
+            prefix = 'histograms_Run'
+            postfix = 'h5'
         else:
             prefix = 'run'
             postfix = 'mid.gz'

--- a/reconstruction.py
+++ b/reconstruction.py
@@ -117,8 +117,8 @@ class analysis:
             pics = [k for k in tf.keys() if 'pic' in k]
             return len(pics)
         elif options.rawdata_tier == 'h5':
-            hf = sw.swift_read_h5_file(self.tmpname)
-            pics = [k for k in hf.keys() if 'pic' in k]
+            tf = sw.swift_read_h5_file(self.tmpname)
+            pics = [k for k in tf.keys() if 'pic' in k]
             print("n events:", len(pics))
             return len(pics)
         else:
@@ -309,9 +309,8 @@ class analysis:
             keys = tf.keys()
             mf = [0] # dummy array to make a common loop with MIDAS case
         elif self.options.rawdata_tier == 'h5':
-            hf = sw.swift_read_h5_file(self.tmpname)
-            keys = hf.keys()
-            print(keys)
+            tf = sw.swift_read_h5_file(self.tmpname)
+            keys = tf.keys()
             mf = [0] # dummy array to make a common loop with MIDAS case
 
         else:
@@ -349,10 +348,7 @@ class analysis:
                         m = patt.match(name)
                         run = int(m.group(1))
                         event = int(m.group(2))
-                        print(key)
-                        print(hf[key])
-                        obj = np.array(hf[key])
-                        print(obj.shape)
+                        obj = np.array(tf[key])
                         #obj = np.rot90(obj)
                         camera=True
                     else:

--- a/swiftlib.py
+++ b/swiftlib.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import uproot
 import midas.file_reader
+import h5py
 import cygno as cy
 import os
 
@@ -73,6 +74,10 @@ def swift_read_root_file(tmpname):
     f  = uproot.open(tmpname)
     return f
 
+def swift_read_h5_file(tmpname):
+    f  = h5py.File(tmpname, 'r')
+    return f
+
 def swift_rm_root_file(tmpname):
     import os
     os.remove(tmpname)
@@ -90,11 +95,15 @@ def checkfiletmp(run,tier,tmp=None):
          os.system('mkdir -p {tmpdir}/{user}'.format(tmpdir=tmpdir,user=USER))
          if tier=='root':
              return os.path.isfile("%s/%s/histograms_Run%05d.root" % (tmpdir,USER,run))
+         elif tier=='h5':
+             return os.path.isfile("%s/%s/histograms_Run%05d.h5" % (tmpdir,USER,run))
          else:
              return os.path.isfile("%s/%s/run%05d.mid.gz" % (tmpdir,USER,run))
     else:
         if tier=='root':
             return os.path.isfile("%s/histograms_Run%05d.root" % (tmpdir,run))
+        elif tier=='h5':
+            return os.path.isfile("%s/histograms_Run%05d.h5" % (tmpdir,run))
         else:
             return os.path.isfile("%s/run%05d.mid.gz" % (tmpdir,run))
 


### PR DESCRIPTION
To solve uproot memory leak, at least for the moment, I added the option to set 'rawdata_tier' : 'h5', for simulated images (the simulation now produces h5 files). This way the leak is partially solved. The memory still increases a bit, probably due to the use of uproot when subtracting pedestals.

The code runs smoothly, the images seem to be okay: they appear in the right position and with the right shape.   
 
I also updated the instructions to run the reconstruction on simulated images.