### PR TITLE
Fix reading n. events in LNF runlog file

### DIFF
--- a/utilities.py
+++ b/utilities.py
@@ -289,9 +289,13 @@ class utils:
                 csvreader = csv.reader(csvfile, delimiter=',', quotechar='"')
                 # This skips the first row (header) of the CSV file.
                 next(csvreader)
+                if detector == "LNF":
+                    n_ev_col = -1 
+                else:
+                    n_ev_col = -2
                 for row in reversed(list(csvreader)):
                     runkey,runtype,comment = row[:3]
-                    nevents = int(row[-2]) if str(row[-2]).strip()!="NULL" else 0
+                    nevents = int(row[n_ev_col]) if str(row[n_ev_col]).strip()!="NULL" else 0
                     if int(runkey)<=int(options.run) and (":PED:" in runtype) and nevents>=100:
                         options.pedrun = int(runkey)
                         print("Will use pedestal run %05d which has comment: '%s' and n of events: '%d'" % (int(runkey),comment,int(nevents)))


### PR DESCRIPTION
In the LNF runlog file the number of events is the last column. Now everything is fine. I tested the code. 