### PR TITLE
Winter23

### DIFF
--- a/configFile_LNGS.txt
+++ b/configFile_LNGS.txt
@@ -44,7 +44,7 @@
 'excImages'             : [], #list(range(5))+[],      # To exlude some images of the analysis. Always exclude the first 5 which are messy (not true anymore)
 'donotremove'           : True,                   # Remove or not the file from the tmp folder
 
-'scfullinfo'            : False,			   # If True some the supercluster pixels info will be saved
+'scfullinfo'            : True, 			   # If True some the supercluster pixels info will be saved
 'save_MC_data'          : False,			   # If True save the MC informations
 
 'tip'                   : '3D',

--- a/corrections/test_regression.py
+++ b/corrections/test_regression.py
@@ -208,6 +208,7 @@ def response2D(inputfile,paramsfile,panda=None):
 
     ROOT.gStyle.SetPaintTextFormat("1.2f");
 
+    otumap = ROOT.TFile.Open('response2D.root','recreate')
     c = getCanvas('c')
     for k,h3D in energy_2Ds.items():
         for ix in range(1,h3D.GetNbinsX()+1):
@@ -234,13 +235,18 @@ def response2D(inputfile,paramsfile,panda=None):
                         zbinmax = iz
                 energy_2D_modes[k].SetBinContent(ix,iy,h3D.GetZaxis().GetBinCenter(zbinmax))
         energy_2D_modes[k].Draw("colz") # text45")
-        c.SaveAs("{target}_2D_{name}.png".format(target=GBR.target.replace('sc_',''),name=k))
+        for ext in ['png','pdf']:
+            c.SaveAs("{target}_2D_{name}.{ext}".format(target=GBR.target.replace('sc_',''),name=k),ext=ext)
 
     energy_2D_modes['ratio'] = energy_2D_modes['regr'].Clone('energy_2D_mode_ratio')
     energy_2D_modes['ratio'].Divide(energy_2D_modes['uncorr'])
     energy_2D_modes['ratio'].Draw("colz") # text45")
-    c.SaveAs("%s_2D_ratio.png" % GBR.target.replace('sc_',''))
-    
+    for ext in ['png','pdf']:
+        c.SaveAs("%s_2D_ratio.png" % GBR.target.replace('sc_',''),ext=ext)
+
+    outmap.cd()
+    energy_2D_modes['ratio'].Write()
+    outmap.Close()
     
     # energy_1Ds['uncorr'].SetMarkerColor(ROOT.kBlack)
     # energy_1Ds['regr'].SetMarkerColor(ROOT.kRed)
@@ -523,4 +529,4 @@ if __name__ == '__main__':
     (options, args) = parser.parse_args()
 
     makeResponseHistos(args[0],args[1],panda=options.loadPanda)
-    graphVsR("fit",target=options.target)
+    #graphVsR("fit",target=options.target)

--- a/modules_config/reco_eventcontent.txt
+++ b/modules_config/reco_eventcontent.txt
@@ -2,8 +2,8 @@
 
 'scfullinfo'            : True,			   # If True some the supercluster pixels info will be saved
 'scpixels_sel'          :  {                               # To reduce the event content when saving the pixels
-                           'max_len' : 50,
-                           'min_integral' : 1000
+                           'max_len' : 100000,  # remove completely this cut (output files might be much larger)
+                           'min_integral' : 850 # corresponding to about 0.5 keV with the Run3 typical scale
                            },
 
 'save_MC_data'          : False,			   # If True save the MC informations

--- a/plotter/limeAtLngsRun2/mca-bkgonly.txt
+++ b/plotter/limeAtLngsRun2/mca-bkgonly.txt
@@ -1,5 +1,5 @@
-bkg    : merged_golden_run2 : 1 ; FillColor=ROOT.kBlue+1, FillStyle=3004, Label="No source" 
-fakes+ : merged_golden_ped_run2 : 1 ; FillColor=ROOT.kRed+1, Label="Fakes"
+bkg    : merged_golden_run2_rereco : 1 ; FillColor=ROOT.kBlue+1, FillStyle=3004, Label="No source" 
+fakes+ : merged_golden_ped_run2_rereco : 1 ; FillColor=ROOT.kRed+1, Label="Fakes"
 #data   : merged_golden_calib_run2 : 1 ; FillColor=ROOT.kRed+1, Label="Source"
-data   : merged_golden_calib_run2 : (7828./887.)*(run==11285 || run==11587 || run==11956 || run==12172) ; FillColor=ROOT.kRed+1, Label="Source"
+data   : merged_golden_calib_run2_rereco : (7828./887.)*(run==11285 || run==11587 || run==11956 || run==12172) ; FillColor=ROOT.kRed+1, Label="Source"
 #data  : merged_feruns_8882_9857 : 1 ;  FillColor=ROOT.kRed+1, Label="Source"


### PR DESCRIPTION
Save the pixels belonging to the reconstructed clusters with an energy >~ 0.5 keV (no cut on the track length).
Output files could be a bit larger, but it was retained needed in view of characterization of NR in view of AmBe run with LIME.

@igorabritta please update the winter23 branch in the place where the central reconstruction is run.
@davidepinci @baracch for reference
@gdimperi this will also affect the size of the reco of SIM events: not sure if it is needed or not

