### PR TITLE
go back to the setPedestal original method

### DIFF
--- a/reconstruction.py
+++ b/reconstruction.py
@@ -574,7 +574,7 @@ if __name__ == '__main__':
     patt = re.compile('\S+_(\S+).txt')
     m = patt.match(args[0])
     detector = m.group(1)
-    if run > 16798 :
+    if run > 99999999 :
         utilities.setPedestalRun_v2(options,detector)
     else:
         utilities.setPedestalRun(options,detector)

--- a/utilities.py
+++ b/utilities.py
@@ -295,7 +295,7 @@ class utils:
                         pedestal_flag = int(row[-12]) # count from the end, because the field [1] is a txt run description that sometimes has ","...
                     else:
                         pedestal_flag = (":PED:" in runtype)
-                    nevents = int(row[-2]) if str(row[-2]).strip()!="NULL" else 0
+                    nevents = int(row[-2]) if (str(row[-2]).strip()not in ["NULL",'']) else 0
                     if int(runkey)<=int(options.run) and pedestal_flag and nevents>=100:
                         options.pedrun = int(runkey)
                         print("Will use pedestal run %05d which has comment: '%s' and n of events: '%d'" % (int(runkey),comment,int(nevents)))


### PR DESCRIPTION
...which I fixed counting from the back in the manual parsing. I don't know if the auto CSV is cleaned for this kind of possible problem.

@antorita @igorabritta this was introduced in PR #216 : the pedestal runs are wrong if the field "run_description" has a ",", which is likely the case, it seems (see " Daily Calibration, parking" for Run3, or "S000:PED:BKG, no pmt" for Run1/Run2. 
I manually avoided this by counting from the bottom, but with [this code](https://github.com/CYGNUS-RD/reconstruction/pull/216/files#diff-a1ad108b8591f172c80a5bcfadc6014b078331b5286137ee126f4c8e616069edR310-R311) this is not done, I think.

@igorabritta do you clean the downloaded CSV to avoid these cases? Otherwise I suggest to go back to the old pedestal setting. 

Let's not use commas in the run_description in the future

@igorabritta @antorita @davidepinci if confirmed the problem was there, let's see since when we should re-reco the runs with the fix (I can do it)

Nota bene: in the original method the csv used is "pedestals/runlog_LNGS.csv", in the v2 is "pedestals/runlog_auto.csv". 
Let's use the same name (otherwise I think one has to change either in the automated reco or in the LNGS batch reco for no reason).

