### PR TITLE
Fixing ransac error and updating old pedestal table

### DIFF
--- a/cluster/ddbscan_inner.py
+++ b/cluster/ddbscan_inner.py
@@ -120,13 +120,22 @@ def ddbscaninner(data, is_core, neighborhoods, neighborhoods2, labels, dir_radiu
             x = data[labels==label_num][:,0]
             y = data[labels==label_num][:,1]
             if (np.median(np.abs(y - np.median(y))) == 0):
-                ransac = RANSACRegressor(min_samples=0.8, residual_threshold = 0.1)
-                ransac.fit(np.expand_dims(x, axis=1), y)
+                try:
+                    ransac = RANSACRegressor(min_samples=0.8, residual_threshold = 0.1)
+                    ransac.fit(np.expand_dims(x, axis=1), y)
+                    accuracy = sum(ransac.inlier_mask_)/len(y)
+                except ValueError as e:
+                    print("RANSAC first attempt error (MAD = 0):", e)
+                    accuracy = 0
             else:
-                ransac = RANSACRegressor(min_samples=0.8)
-                ransac.fit(np.expand_dims(x, axis=1), y)
-            
-            accuracy = sum(ransac.inlier_mask_)/len(y)
+                try:
+                    ransac = RANSACRegressor(min_samples=0.8)
+                    ransac.fit(np.expand_dims(x, axis=1), y)
+                    accuracy = sum(ransac.inlier_mask_)/len(y)
+                except ValueError as e:
+                    print("RANSAC first attempt error (MAD > 0):", e)
+                    accuracy = 0
+
             if debug:
                 print("-----> accuracy = ",accuracy)
             
@@ -136,14 +145,22 @@ def ddbscaninner(data, is_core, neighborhoods, neighborhoods2, labels, dir_radiu
                 y_rot = x * np.sin(np.pi/4) + (y * np.sin(np.pi/4)) 
                 
                 if (np.median(np.abs(y_rot - np.median(y_rot))) == 0):
-                    ransac = RANSACRegressor(min_samples=0.5, residual_threshold = 0.1)
-                    ransac.fit(np.expand_dims(x_rot, axis=1), y_rot)
+                    try:
+                        ransac = RANSACRegressor(min_samples=0.5, residual_threshold = 0.1)
+                        ransac.fit(np.expand_dims(x_rot, axis=1), y_rot)
+                        accuracy = sum(ransac.inlier_mask_)/len(y_rot)
+                    except ValueError as e:
+                        print("RANSAC after rotation error (MAD = 0):", e)
+                        accuracy = 0
                 else:
-                    ransac = RANSACRegressor(min_samples=0.5)
-                    ransac.fit(np.expand_dims(x_rot, axis=1), y_rot)
-
-                accuracy = sum(ransac.inlier_mask_)/len(y_rot)
-                
+                    try:
+                        ransac = RANSACRegressor(min_samples=0.5)
+                        ransac.fit(np.expand_dims(x_rot, axis=1), y_rot)
+                        accuracy = sum(ransac.inlier_mask_)/len(y_rot)
+                    except ValueError as e:
+                        print("RANSAC after rotation error (MAD > 0):", e)
+                        accuracy = 0
+                        
                 if debug:
                     print("-----> accuracy after rotation = ",accuracy)
             


### PR DESCRIPTION
The error that was interrupting the reconstruction was on the dbscan seeding step, when each cluster is being tested with the RANSAC. It occurs when no polynomial model can be found for those coordinates.  If no model can be easily found, it is probably a disposable cluster for the directional procedure. For this reason, I've added extra lines on the code to avoid interrupting the entire procedure and just tag that cluster as not directional (a few prints were also implemented to help locate where the error was happening).

I've also updated the runlog_LNGS_auto.csv with @igorabritta's code on 04/08 to make sure to use the correct pedestal on my tests (since it hasn't been updated in a while on git and the last PR did not touch it, I believe it's alright).