### PR TITLE
Small correction for USER setup and try except addition for slowcontrol

### DIFF
--- a/reconstruction.py
+++ b/reconstruction.py
@@ -343,8 +343,14 @@ class analysis:
                 dslow = pd.DataFrame(columns = header_environment)
                 dslow.loc[len(dslow)] = value_variables['Input']
                 for i in dslow.keys():
-                    dslow = utilities.conversion_env_variables(dslow, odb, i, j = 0)
-                self.autotree.fillEnvVariables(dslow.take([0]))
+                    try:
+                       dslow = utilities.conversion_env_variables(dslow, odb, i, j = 0)
+                    except:
+                       print("WARNING: conversion_env_variables failed.")
+                try:
+                   self.autotree.fillEnvVariables(dslow.take([0]))
+                except:
+                   print("WARNING: could not fill dslow variables.")   
                 #print(dslow)
                 j = 1
         
@@ -584,7 +590,10 @@ if __name__ == '__main__':
         flag_env = 0
     except:
         flag_env = 1
-        USER = os.environ['JUPYTERHUB_USER']
+        try:
+          USER = os.environ['JUPYTERHUB_USER']
+        except:
+          USER = "autoreco"
     #tmpdir = '/mnt/ssdcache/' if os.path.exists('/mnt/ssdcache/') else '/tmp/'
     # it seems that ssdcache it is only mounted on cygno-login, not in the batch queues (neither in cygno-custom)
     tmpdir = '/tmp'

--- a/swiftlib.py
+++ b/swiftlib.py
@@ -55,7 +55,10 @@ def swift_download_root_file(url,run,tmp=None,justName=False):
     try:
         USER = os.environ['USER']
     except:
-        USER = os.environ['JUPYTERHUB_USER']
+        try:
+          USER = os.environ['JUPYTERHUB_USER']
+        except
+          USER = "autoreco"
     tmpdir = tmp if tmp else '/tmp/'
     if tmpdir == '/tmp/':
          os.system('mkdir -p {tmpdir}/{user}'.format(tmpdir=tmpdir,user=USER))
@@ -84,7 +87,10 @@ def checkfiletmp(run,tier,tmp=None):
     try:
         USER = os.environ['USER']
     except:
-        USER = os.environ['JUPYTERHUB_USER']
+        try:
+          USER = os.environ['JUPYTERHUB_USER']
+        except
+          USER = "autoreco"
     tmpdir = tmp if tmp else '/tmp/'
          
     

--- a/swiftlib.py
+++ b/swiftlib.py
@@ -57,7 +57,7 @@ def swift_download_root_file(url,run,tmp=None,justName=False):
     except:
         try:
           USER = os.environ['JUPYTERHUB_USER']
-        except
+        except:
           USER = "autoreco"
     tmpdir = tmp if tmp else '/tmp/'
     if tmpdir == '/tmp/':
@@ -89,7 +89,7 @@ def checkfiletmp(run,tier,tmp=None):
     except:
         try:
           USER = os.environ['JUPYTERHUB_USER']
-        except
+        except:
           USER = "autoreco"
     tmpdir = tmp if tmp else '/tmp/'
          


### PR DESCRIPTION
Correction for the autoreco uSER setup.
Addition of try except for bank reading of slow control which crashed the reco rarely. This is temporary as full update is expected.