### PR TITLE
Expand raw data tier handling for h5

### DIFF
--- a/reconstruction.py
+++ b/reconstruction.py
@@ -162,7 +162,7 @@ class analysis:
 
         pedsum = np.zeros((nx,ny))
 
-        if options.rawdata_tier == 'root':
+        if options.rawdata_tier == 'root' or options.rawdata_tier == 'h5':
             tmpdir = '{tmpdir}'.format(tmpdir=options.tmpdir if options.tmpdir else "/tmp/")
             if not sw.checkfiletmp(int(options.pedrun),'root',tmpdir):
                 print ('Downloading file: ' + sw.swift_root_file(options.tag, int(options.pedrun)))


### PR DESCRIPTION
I've expanded the condition to also include the case where `options.rawdata_tier` is equal to 'h5'. Everything runs smoothly.