### PR TITLE
There is a return of a function in *snakes.py* that returns *lp_len* that is not defined

### DIFF
--- a/snakes.py
+++ b/snakes.py
@@ -108,6 +108,7 @@ class SnakesFactory:
 
         # clustering will crash if the vector of pixels is empty (it may happen after the zero-suppression + noise filtering)
         if len(X)==0:
+            lp_len=0
             return superclusters, lp_len, t_medianfilter, t_noisered, t_DBSCAN 
 
         if self.options.debug_mode:

--- a/snakes.py
+++ b/snakes.py
@@ -108,8 +108,7 @@ class SnakesFactory:
 
         # clustering will crash if the vector of pixels is empty (it may happen after the zero-suppression + noise filtering)
         if len(X)==0:
-            lp_len=0
-            return superclusters, lp_len, t_medianfilter, t_noisered, t_DBSCAN 
+            return superclusters, lp, t_medianfilter, t_noisered, t_DBSCAN 
 
         if self.options.debug_mode:
             if self.options.flag_dbscan_seeds:


### PR DESCRIPTION
Indeed in the function *getClusters()* only *lp* is defined and not *lp_len*. Now it returns correctly (if len(X)==0) *lp* instead of *lp_len*