### PR TITLE
Fix length and width variables and remove a print

### DIFF
--- a/cluster/ddbscan_inner.py
+++ b/cluster/ddbscan_inner.py
@@ -184,7 +184,7 @@ def ddbscaninner(data, is_core, neighborhoods, neighborhoods2, labels, dir_radiu
         la_aux = np.copy(labels)
         labels = np.zeros([la_aux.shape[0],2], dtype=np.intp)
         labels[:,0] = la_aux
-        print("Clustering ends at DBSCAN seeding")
+        #print("Clustering ends at DBSCAN seeding")
         return labels
     else:
         #If any cluster has a good fit model, it'll be marked from the worst fitted cluster to the best, each of them respecting the accuracy threshold

--- a/clusterTools.py
+++ b/clusterTools.py
@@ -331,13 +331,13 @@ class Cluster:
         from profiling import PeakFinder,simplePeak
 
         # find first the length/width with intersection of the base of the large peak
-        threshold = 3
-        min_distance_peaks = 5 # number of bins of the profile, to be converted in mm later... TO DO
-        prominence = 2 # noise seems <1
-        width = 10  # find only 1 big peak
-        pf = PeakFinder(self.profiles[name])        
-        pf.findPeaks(threshold,min_distance_peaks,prominence,width)
-        self.widths[name] = pf.getFWHMs()[0] if len(pf.getFWHMs()) else 0 # first should be the only big peak
+        #threshold = 3
+        #min_distance_peaks = 5 # number of bins of the profile, to be converted in mm later... TO DO
+        #prominence = 2 # noise seems <1
+        #width = 10  # find only 1 big peak
+        #pf = PeakFinder(self.profiles[name])        
+        #pf.findPeaks(threshold,min_distance_peaks,prominence,width)
+        #self.widths[name] = pf.getFWHMs()[0] if len(pf.getFWHMs()) else 0 # first should be the only big peak
         self.shapes['%s_width' % name] = self.widths[name]
         
         # find the peaks and store their properties


### PR DESCRIPTION
A print was removed as deemed unnecessary.
A part of clusterShapes was commented as it was before the merge with PMT reco. This uncomment broke the length and width variable calculations.