### PR TITLE
Modification of pedestal search

### DIFF
--- a/configFile_LNF.txt
+++ b/configFile_LNF.txt
@@ -28,7 +28,7 @@
 
 # Setting environments parameters
 
-'offline'               : True,		#if False it reads the logbook from online, if true it reads the runlog_tag_auto.csv locally
+'offline'               : False,		#if False it reads the logbook from online, if true it reads the runlog_tag_auto.csv locally
 'rebin'                 : 4,
 'nsigma'                : 0.8,
 'min_neighbors_average' : 1.3,                   # cut on the minimum average energy around a pixel (remove isolated macro-pixels)

--- a/configFile_LNF.txt
+++ b/configFile_LNF.txt
@@ -28,8 +28,7 @@
 
 # Setting environments parameters
 
-'numPedEvents'          : -1,
-'pedExclRegion'         : None,
+'offline'               : True,		#if False it reads the logbook from online, if true it reads the runlog_tag_auto.csv locally
 'rebin'                 : 4,
 'nsigma'                : 0.8,
 'min_neighbors_average' : 1.3,                   # cut on the minimum average energy around a pixel (remove isolated macro-pixels)

--- a/configFile_LNGS.txt
+++ b/configFile_LNGS.txt
@@ -28,8 +28,7 @@
 
 # Setting environments parameters
 
-'numPedEvents'          : -1,
-'pedExclRegion'         : None,
+'offline'               : False,		#if False it reads the logbook from online, if true it reads the runlog_tag_auto.csv locally
 'rebin'                 : 4,
 'nsigma'                : 0.6,
 'min_neighbors_average' : 1.2,                   # cut on the minimum average energy around a pixel (remove isolated macro-pixels)

--- a/configFile_MANGO.txt
+++ b/configFile_MANGO.txt
@@ -28,8 +28,7 @@
 
 # Setting environments parameters
 
-'numPedEvents'          : -1,
-'pedExclRegion'         : None,
+'offline'               : False,		#if False it reads the logbook from online, if true it reads the runlog_tag_auto.csv locally
 'rebin'                 : 4,
 'nsigma'                : 1.8,
 'min_neighbors_average' : 1.1,                   # cut on the minimum average energy around a pixel (remove isolated macro-pixels)

--- a/configFile_MC.txt
+++ b/configFile_MC.txt
@@ -28,8 +28,7 @@
 
 # Setting environments parameters
 
-'numPedEvents'          : -1,
-'pedExclRegion'         : None,
+'offline'               : False,		#if False it reads the logbook from online, if true it reads the runlog_tag_auto.csv locally
 'rebin'                 : 4,
 'nsigma'                : 0.9,
 'min_neighbors_average' : 1.1,                   # cut on the minimum average energy around a pixel (remove isolated macro-pixels)

--- a/utilities.py
+++ b/utilities.py
@@ -317,7 +317,7 @@ class utils:
                runlog='runlog_%s_auto.csv' % (options.tag)
                df = pd.read_csv('pedestals/%s'%runlog)
                
-            dffilter = ((df["number_of_events"] >= 100) & (df["pedestal_run"] == 1) & (df["run_number"] <= int(options.run)) & (df["HV_STATE"] == 0))
+            dffilter = ((df["number_of_events"] >= 100) & (df["pedestal_run"] == 1) & (df["run_number"] <= run) & (df["HV_STATE"] == 0))
             runkey = df.run_number[dffilter].values.tolist()[-1]
             comment = df.run_description[dffilter].values.tolist()[-1]
             nevents = df.number_of_events[dffilter].values.tolist()[-1]

--- a/utilities.py
+++ b/utilities.py
@@ -307,12 +307,16 @@ class utils:
 
     def setPedestalRun_v2(self,options):
         import pandas as pd
+        import cygno as cy
+        
         if not hasattr(options,"pedrun"):
-            runlog='runlog_%s_auto.csv' % (options.tag)
-
- 
-
-            df = pd.read_csv('pedestals/%s'%runlog)
+            run = int(options.run)
+            if options.offline==False:
+               df = cy.read_cygno_logbook(tag=options.tag,start_run=run-2000,end_run=run+1)
+            else:
+               runlog='runlog_%s_auto.csv' % (options.tag)
+               df = pd.read_csv('pedestals/%s'%runlog)
+               
             dffilter = ((df["number_of_events"] >= 100) & (df["pedestal_run"] == 1) & (df["run_number"] <= int(options.run)) & (df["HV_STATE"] == 0))
             runkey = df.run_number[dffilter].values.tolist()[-1]
             comment = df.run_description[dffilter].values.tolist()[-1]
@@ -327,7 +331,7 @@ class utils:
         
     def setPedestalRun(self,options):
         run = int(options.run)
-        if (options.tag=='LNF' and run>10093) or (options.tag=='LNGS' and run>16798) or (options.tag=='MAN' and run>11166):
+        if (options.tag=='LNF' and run>10093) or (options.tag=='LNGS') or (options.tag=='MAN' and run>11166):
            self.setPedestalRun_v2(options)
         #elif (options.tag=='LNGS' and run>936 and run<16798):
         #   self.setPedestalRun_v1(options)


### PR DESCRIPTION
Modification to the configFiles. Removed two unused options and added the offline one in synergy with the utilities.py change.
Now if offline is set to false, the logbook is read from the cygno libs directly instead of using the csv of the runlog (this is still available with offline flag on True). This way there is no need to update the runlog locally.

LNGS always reads the cygno logbook, it works also for old runs.
