### PR TITLE
Fix to uproot memory leak issues for ROOT data files

### DIFF
--- a/reconstruction.py
+++ b/reconstruction.py
@@ -279,7 +279,7 @@ class analysis:
                         justSkip=False
                         if (numev in self.options.excImages) and self.options.justPedestal: justSkip=True
                         if (maxImages>-1 and numev>min(len(keys),maxImages)) and self.options.justPedestal: break
-                        if numev>200: break # no need to compute pedestals with >200 evts (avoid large RAM usage)
+                        if numev>250: break # no need to compute pedestals with >250 evts
                             
                         if numev%20 == 0:
                             print("Calc pedestal mean with event: ",numev)
@@ -300,7 +300,7 @@ class analysis:
                 justSkip=False
                 if (numev in self.options.excImages) and self.options.justPedestal: justSkip=True
                 if (maxImages>-1 and numev>min(len(keys),maxImages)) and self.options.justPedestal: break
-                if numev>100: break # impossible to compute pedestals with >100 evts (uproot issue)
+                if numev>250: break # no need to compute pedestals with >250 evts
                 if 'pic' not in name: justSkip=True
                 if justSkip:
                     continue
@@ -329,7 +329,7 @@ class analysis:
                         justSkip=False
                         if (numev in self.options.excImages) and self.options.justPedestal: justSkip=True
                         if (maxImages>-1 and numev>min(len(keys),maxImages)) and self.options.justPedestal: break
-                        if numev>200: break # no need to compute pedestals with >200 evts (avoid large RAM usage)
+                        if numev>250: break # no need to compute pedestals with >250 evts 
              
                         if numev%20 == 0:
                             print("Calc pedestal rms with event: ",numev)
@@ -349,7 +349,7 @@ class analysis:
                 justSkip=False
                 if (numev in self.options.excImages) and self.options.justPedestal: justSkip=True
                 if (maxImages>-1 and numev>min(len(keys),maxImages)) and self.options.justPedestal: break
-                if numev>100: break # impossible to compute pedestals with >100 evts (uproot issue)
+                if numev>250: break # no need to compute pedestals with >250 evts
                 if 'pic' not in name: justSkip=True
                 if justSkip:
                      continue

--- a/swiftlib.py
+++ b/swiftlib.py
@@ -70,7 +70,7 @@ def swift_download_root_file(url,run,tmp=None,justName=False):
     return tmpname 
 
 def swift_read_root_file(tmpname):
-    f  = uproot.open(tmpname)
+    f  = uproot.open(tmpname,object_cache=None, array_cache=None)
     return f
 
 def swift_read_h5_file(tmpname):


### PR DESCRIPTION
Found fix to avoid memory leaks. Tested on creation of pedestal with 150 images. Before it was crashing before completing with 8GB RAM and 2 GB of swap. Now It succeeded without exceeding 2.5 GB of RAM