### PR TITLE
Adding timestamp branch also foreseeing changes in DAQ

### DIFF
--- a/reconstruction.py
+++ b/reconstruction.py
@@ -446,6 +446,8 @@ class analysis:
         exist_pmt = False
         exist_cam = False
         fails_count = 0
+        timestamp = -1
+        timestamp0 = 0
 
         for mevent in mf:
             if self.options.rawdata_tier == 'midas':
@@ -469,13 +471,15 @@ class analysis:
                     else:
                          exist_pmt = False
                          exist_cam = False   
+            
+            if self.options.rawdata_tier == 'midas':
+                timestamp=mevent.header.timestamp
 
             for iobj,key in enumerate(keys):
                 name=key
                 camera = False
                 pmt = False
                 #print(name)
-
 
                 if self.options.rawdata_tier == 'root':
                     if 'pic' in name:
@@ -497,6 +501,13 @@ class analysis:
 
                 elif self.options.rawdata_tier == 'midas':
                     run = int(self.options.run)
+
+                    if name == 'TIME':
+                        timestamp0 = mevent.banks[key].data[0]
+                        #print(timestamp0,timestamp)
+                    if timestamp<10000:             #10000 in seconds is 2h 46 min. This time should be larger than the run duration
+                        timestamp = timestamp0*1000 + timestamp
+                    
                     if name.startswith('CAM'):
                         camera_read = True
                         exist_cam = True
@@ -627,7 +638,7 @@ class analysis:
                         t_DBSCAN_2 = time.perf_counter()
                         if self.options.debug_mode == 1:
                             print(f"1. DBSCAN run + variables calculation in {t_DBSCAN_2 - t_DBSCAN_1:0.4f} seconds")
-                        self.autotree.fillCameraVariables(img_fr_zs)
+                        self.autotree.fillCameraVariables(img_fr_zs,timestamp)
                         t_DBSCAN_3 = time.perf_counter()
                         if self.options.debug_mode == 1:
                             print(f"fillCameraVariables in {t_DBSCAN_3 - t_DBSCAN_2:0.4f} seconds")

--- a/treeVars.py
+++ b/treeVars.py
@@ -164,6 +164,7 @@ class AutoFillTreeProducer:
         self.outTree.branch('cmos_integral', 'F', title="integral counts of the full CMOS sensor")
         self.outTree.branch('cmos_mean',     'F', title="average counts of the full CMOS sensor")
         self.outTree.branch('cmos_rms',      'F', title="RMS of the counts of the full CMOS sensor")
+        self.outTree.branch('timestamp',      'L', title="Timestamp in UTC of the picture")
 
     def createTimeCameraVariables(self):
         self.outTree.branch('t_DBSCAN', 'F', title="DBSCAN time")
@@ -230,10 +231,11 @@ class AutoFillTreeProducer:
         self.outTree.branch('{name}_lchi2'.format(name=name),        'F', lenVar=sizeStr, title="chi-squared of the Gaussian fit to the longitudinal profile")
         self.outTree.branch('{name}_lstatus'.format(name=name),      'F', lenVar=sizeStr, title="status of the Gaussian fit to the longitudinal profile")
 
-    def fillCameraVariables(self,pic):
+    def fillCameraVariables(self,pic,timestamp):
         self.outTree.fillBranch('cmos_integral',np.sum(pic))
         self.outTree.fillBranch('cmos_mean',np.mean(pic))
         self.outTree.fillBranch('cmos_rms',np.std(pic))
+        self.outTree.fillBranch('timestamp',timestamp)
 
     def fillTimeCameraVariables(self, t_variables, t_DBSCAN, lp, t_pedsub, t_saturation, t_zerosup, t_xycut, t_rebin, t_medianfilter, t_noisered):
         self.outTree.fillBranch('t_DBSCAN', t_DBSCAN)


### PR DESCRIPTION
Added timestamp variable and saved in timestamp tree (long long int variable).
Tested on ROOT files where timestamp is filled with -1
Tested on current midas files: timestamp read on the event header (UTC in s) and stored
Tested on soon to be updated DAQ, where an extra TIME bank will be present. The header of the event will contain the ms of time difference with respect to reference time in UTC s saved in TIME. The timestamp will be saved as a long long int in UTC ms