### PR TITLE
Addition executable definition at the beginning of reconstruction.py

### DIFF
--- a/reconstruction.py
+++ b/reconstruction.py
@@ -1,3 +1,5 @@
+#! /usr/bin/env python3
+
 import os
 cythonized=False
 for fname in os.listdir('.'):


### PR DESCRIPTION
Addition executable definition at the beginning of reconstruction.py
This is required to have the reco to run on the cnaf tier queues.