### PR TITLE
fix the ambiguity of 180 degrees in the cluster theta definition

### DIFF
--- a/clusterTools.py
+++ b/clusterTools.py
@@ -148,9 +148,13 @@ class Cluster:
         mat = np.array([self.x,self.y])
         covmat = np.cov(mat.astype(float))
         eig_values, eig_vecs = np.linalg.eig(covmat)
+
         indexes = (np.argmax(eig_values),np.argmin(eig_values))
-        eig_vec_vals = (eig_vecs[:, indexes[0]], eig_vecs[:, indexes[-1]])
-        theta = np.degrees(np.arctan2(*eig_vecs[:,0][::-1]))
+        major_vec = eig_vecs[:, indexes[0]]
+        minor_vec = eig_vecs[:, indexes[-1]]
+        eig_vec_vals = (major_vec, minor_vec)
+        
+        theta = np.degrees(np.arctan2(major_vec[1], major_vec[0])) % 180
         return eig_vec_vals,theta
 
     def plotAxes(self,plot):


### PR DESCRIPTION
The eigenvectors directions have no sign, so there is an ambiguity between $\theta$ and $\theta + 180^\circ$. 
The fix returns the theta angle always in [0,180) range. 

This changes the meaning of the `sc_theta` variable in the trees, but if one implements the fix on top of this variable as 

`sc_theta` $\rightarrow$ `sc_theta % 180`

the output is consistent for both older and new version of the ntuples. 

Examples of cases with toy MC generation of points attached 
[quadrant_30.pdf](https://github.com/user-attachments/files/25364072/quadrant_30.pdf)
[quadrant_120.pdf](https://github.com/user-attachments/files/25364073/quadrant_120.pdf)
[quadrant_210.pdf](https://github.com/user-attachments/files/25364075/quadrant_210.pdf)
[quadrant_300.pdf](https://github.com/user-attachments/files/25364077/quadrant_300.pdf)

@davidepinci 